### PR TITLE
Add `\forall` and `\exists`

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -112,6 +112,16 @@ var symbols = {
             group: "textord",
             replace: "\u03a9"
         },
+        "\\forall": {
+            font: "main",
+            group: "textord",
+            replace: "\u2200"
+        },
+        "\\exists": {
+            font: "main",
+            group: "textord",
+            replace: "\u2203"
+        },
         "\\alpha": {
             font: "main",
             group: "mathord",


### PR DESCRIPTION
I added `\forall` and `\exists`, so KaTeX is now able to render this:
```tex
\forall x \in X, \quad \exists y \leq \epsilon
```
I don't now exactly the group that I should use for this two arrows, I use "textord" maybe it should be "op". 