### PR TITLE
Add ominus symbol to symbols.js

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -107,11 +107,6 @@ var symbols = {
             group: "textord",
             replace: "\u03a8"
         },
-        "\\psi": {
-            font: "main",
-            group: "mathord",
-            replace: "\u03c8"
-        },
         "\\Omega": {
             font: "main",
             group: "textord",
@@ -226,6 +221,11 @@ var symbols = {
             font: "main",
             group: "mathord",
             replace: "\u03c7"
+        },
+        "\\psi": {
+            font: "main",
+            group: "mathord",
+            replace: "\u03c8"
         },
         "\\omega": {
             font: "main",

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -107,6 +107,11 @@ var symbols = {
             group: "textord",
             replace: "\u03a8"
         },
+        "\\psi": {
+            font: "main",
+            group: "mathord",
+            replace: "\u03c8"
+        },
         "\\Omega": {
             font: "main",
             group: "textord",
@@ -221,11 +226,6 @@ var symbols = {
             font: "main",
             group: "mathord",
             replace: "\u03c7"
-        },
-        "\\psi": {
-            font: "main",
-            group: "mathord",
-            replace: "\u03c8"
         },
         "\\omega": {
             font: "main",
@@ -516,6 +516,11 @@ var symbols = {
             font: "main",
             group: "textord",
             replace: "\u2295"
+        },
+        "\\ominus": {
+            font: "main",
+            group: "textord",
+            replace: "\u2296"
         },
         "\\otimes": {
             font: "main",


### PR DESCRIPTION
I did not change any functional code whatsoever.  I just added support for the ominus symbol(u2296) to complement the oplus symbol that had already been added.

I also had some trouble finding psi, so I moved it up right next to Psi for maximum legibility.  It's a small change, but I hope it helps!