### PR TITLE
add mathbb macro

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -131,6 +131,30 @@ Lexer.prototype._innerLexColor = function(pos) {
     }
 };
 
+
+// A regex to match letters
+var regLetters = /[a-zA-Z]+/i;
+
+/**
+ * This function lexes a raw string of letters.
+ */
+Lexer.prototype._innerLexRawLetters = function(pos) {
+    var input = this._input.slice(pos);
+
+    // Ignore whitespace
+    var whitespace = input.match(whitespaceRegex)[0];
+    pos += whitespace.length;
+    input = input.slice(whitespace.length);
+
+    var match;
+    if ((match = input.match(regLetters))) {
+        // If we look like a letter, return a letter
+        return new LexResult("raw", match[0], pos + match[0].length);
+    } else {
+        throw new ParseError("Not a letter", this, pos);
+    }
+};
+
 // A regex to match a dimension. Dimensions look like
 // "1.2em" or ".4pt" or "1 ex"
 var sizeRegex = /^(\d+(?:\.\d*)?|\.\d+)\s*([a-z]{2})/;
@@ -189,6 +213,8 @@ Lexer.prototype.lex = function(pos, mode) {
         return this._innerLexSize(pos);
     } else if (mode === "whitespace") {
         return this._innerLexWhitespace(pos);
+    } else if (mode === "raw") {
+        return this._innerLexRawLetters(pos);
     }
 };
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -441,6 +441,28 @@ Parser.prototype.parseSpecialGroup = function(pos, mode, outerMode) {
                 new ParseNode("color", inner.text, outerMode),
                 closeBrace.position),
             false);
+    }
+    else if (mode === "raw") {
+        var start = this.lexer.lex(pos, outerMode);
+        if (start.type === "{") {
+            var openBrace = start;
+            var inner = this.lexer.lex(openBrace.position, mode);
+            console.log(inner);
+            var closeBrace = this.lexer.lex(inner.position, outerMode);
+            return new ParseFuncOrArgument(
+                new ParseResult(
+                    new ParseNode("raw", inner.text, outerMode),
+                    closeBrace.position),
+                false);
+        }
+        else {
+            var inner = this.lexer.lex(start.position-1, "math");
+            return new ParseFuncOrArgument(
+                new ParseResult(
+                    new ParseNode("raw", inner.text, outerMode),
+                    start.position),
+                false);
+        }
     } else if (mode === "text") {
         // text mode is special because it should ignore the whitespace before
         // it

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -171,6 +171,12 @@ var groupTypes = {
             group.value, group.mode, options.getColor(), ["mord"]);
     },
 
+    mathbb: function(group, options, prev) {
+        var rawString = group.value.body.value;
+        var metrics = fontMetrics.getCharacterMetrics(rawString, "AMS-Regular");
+        return new domTree.symbolNode(rawString, metrics.height, metrics.depth, metrics.italic, metrics.skew, ["amsrm"]);
+    },
+
     bin: function(group, options, prev) {
         var className = "mbin";
         // Pull out the most recent element. Do some special handling to find

--- a/src/functions.js
+++ b/src/functions.js
@@ -1,6 +1,5 @@
 var utils = require("./utils");
 var ParseError = require("./ParseError");
-
 // This file contains a list of functions that we parse. The functions map
 // contains the following data:
 
@@ -68,6 +67,17 @@ var functions = {
         handler: function(func, body) {
             return {
                 type: "sqrt",
+                body: body
+            };
+        }
+    },
+
+    "\\mathbb": {
+        numArgs: 1,
+        argTypes: ["raw"],
+        handler: function(func, body) {
+            return {
+                type: "mathbb",
                 body: body
             };
         }


### PR DESCRIPTION
okay, this is quite some changes
but I think in this way it also possible to add mathcal, and mathfrak easily

I've implemented it so that it also accepts letters, so that \mathbb{REAL} works, but \mathbb{A+B} wont work. I LaTeX self, you get strange ouput if you do something like \mathbb{R^n} for example:

<a href="http://www.codecogs.com/eqnedit.php?latex=\mathbb{R^n}" target="_blank"><img src="http://latex.codecogs.com/gif.latex?\mathbb{R^n}" title="\mathbb{R^n}" /></a>

I think it is better to just give an error message, saying that it expected letters inside \mathbb. 