### PR TITLE
Improved sqrt layout in some browsers (take 2)

### DIFF
--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -743,8 +743,8 @@ var groupTypes = {
         }
 
         // Shift the delimiter so that its top lines up with the top of the line
-        delimShift = -(inner.height + lineClearance + ruleWidth) + delim.height;
-        delim.style.top = delimShift + "em";
+        var delimShift = -(inner.height + lineClearance + ruleWidth) + delim.height;
+        delim.style.top = (delimShift + line.height / 2) + "em";
         delim.height -= delimShift;
         delim.depth += delimShift;
 


### PR DESCRIPTION
I tested this change on Firefox (27), IE (8 & 10), and Chrome (37) on Windows and Chrome (39), Firefox (30), and Safari (7) on Mac OS X 10.9.4.

Firefox and IE rendering changed looked good before the change and surprisingly didn't change with this change.

Chrome (Mac & Windows) and Firefox (Mac) both improved substantially at large (> 20px) font sizes.  Safari's rendering improved a little bit.

It doesn't solve all rendering issues with ```\sqrt```, but it's a step in the right direction.