### PR TITLE
Experimental extensions implementation (adds support for non-standard \cssId and \class)

### DIFF
--- a/katex.js
+++ b/katex.js
@@ -11,6 +11,10 @@ var ParseError = require("./src/ParseError");
 var buildTree = require("./src/buildTree");
 var parseTree = require("./src/parseTree");
 var utils = require("./src/utils");
+var extensions = require("./src/extensions");
+var css_ext = require("./src/ext/css_ext");
+
+extensions.register(css_ext);
 
 /**
  * Parse and build an expression, and place that expression in the DOM node
@@ -20,7 +24,7 @@ var render = function(toParse, baseNode) {
     utils.clearNode(baseNode);
 
     var tree = parseTree(toParse);
-    var node = buildTree(tree).toNode();
+    var node = buildTree.buildTree(tree).toNode();
 
     baseNode.appendChild(node);
 };
@@ -44,7 +48,7 @@ if (typeof document !== "undefined") {
  */
 var renderToString = function(toParse) {
     var tree = parseTree(toParse);
-    return buildTree(tree).toMarkup();
+    return buildTree.buildTree(tree).toMarkup();
 };
 
 module.exports = {

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -190,6 +190,10 @@ var innerLexers = {
  * Based on the mode, we defer to one of the `_innerLex` functions.
  */
 Lexer.prototype.lex = function(pos, mode) {
+    if (mode instanceof Function) {
+        return mode.call(this, pos);
+    }
+
     if (innerLexers.hasOwnProperty(mode)) {
         return innerLexers[mode].call(this, pos, mode);
     }

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -12,7 +12,6 @@
  */
 
 var Token = require("./Token");
-var extensions = require("./extensions");
 var ParseError = require("./ParseError");
 
 // The main lexer class
@@ -188,25 +187,29 @@ var innerLexers = {
 /**
  * This function lexes a single token starting at `pos` and of the given mode.
  * Based on the mode, we defer to one of the `_innerLex` functions.
+ *
+ * @param {Number} pos
+ * @param {String} mode
+ * @return {Token}
  */
 Lexer.prototype.lex = function(pos, mode) {
-    if (mode instanceof Function) {
-        return mode.call(this, pos);
-    }
-
     if (innerLexers.hasOwnProperty(mode)) {
         return innerLexers[mode].call(this, pos, mode);
     }
-
-    for (var i = 0; i < extensions.exts.length; i++) {
-        var ext = extensions.exts[i];
-        if (ext.mode === mode && ext.lexer) {
-            return ext.lexer.call(this, pos);
-        }
-    }
-
-    throw new ParseError("The '" + mode + "' is not supported yet",
+    throw new ParseError("The '" + mode + "' is not supported.",
         this, pos);
+};
+
+/**
+ * This function lexes a single token start at `pos` using the given custom
+ * lexer.
+ *
+ * @param {Number} pos
+ * @param {Function} lexer
+ * @returns {Token}
+ */
+Lexer.prototype.lexWithCustomLexer = function(pos, lexer) {
+    return lexer.call(this, pos);
 };
 
 module.exports = Lexer;

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -106,7 +106,7 @@ Lexer.prototype._innerLex = function(pos, normals, ignoreWhitespace) {
 
     throw new ParseError("Unexpected character: '" + input[0] +
         "'", this, pos);
-}
+};
 
 // A regex to match a CSS color (like #ffffff or BlueViolet)
 var cssColor = /^(#[a-z0-9]+|[a-z]+)/i;
@@ -128,6 +128,27 @@ Lexer.prototype._innerLexColor = function(pos) {
         return new LexResult("color", match[0], pos + match[0].length);
     } else {
         throw new ParseError("Invalid color", this, pos);
+    }
+};
+
+var cssIdRegex = /^([a-z\-\_][a-z0-9\-\_]*)/i;
+
+/**
+ * This function lexes a CSS id.
+ */
+Lexer.prototype._innerLexCssId = function(pos) {
+    var input = this._input.slice(pos);
+
+    // Ignore whitespace
+    var whitespace = input.match(whitespaceRegex)[0];
+    pos += whitespace.length;
+    input = input.slice(whitespace.length);
+
+    var match;
+    if ((match = input.match(cssIdRegex))) {
+        return new LexResult("cssId", match[0], pos + match[0].length);
+    } else {
+        throw new ParseError("Invalid id", this, pos);
     }
 };
 
@@ -185,6 +206,8 @@ Lexer.prototype.lex = function(pos, mode) {
         return this._innerLex(pos, textNormals, false);
     } else if (mode === "color") {
         return this._innerLexColor(pos);
+    } else if (mode === "cssId") {
+        return this._innerLexCssId(pos);
     } else if (mode === "size") {
         return this._innerLexSize(pos);
     } else if (mode === "whitespace") {

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -428,7 +428,7 @@ Parser.prototype.parseFunction = function(pos, mode) {
  * @return {?ParseFuncOrArgument}
  */
 Parser.prototype.parseSpecialGroup = function(pos, mode, outerMode) {
-    if (mode === "color" || mode === "size") {
+    if (mode === "color" || mode === "size" || mode === "cssId") {
         // color and size modes are special because they should have braces and
         // should only lex a single symbol inside
         var openBrace = this.lexer.lex(pos, outerMode);

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -374,7 +374,7 @@ Parser.prototype.parseFunction = function(pos, mode) {
                 for (var i = 0; i < baseGroup.numArgs; i++) {
                     var argType = baseGroup.argTypes && baseGroup.argTypes[i];
                     if (argType) {
-                        var arg = this.parseSpecialGroup(newPos, argType, mode);
+                        var arg = this.parseSpecialGroup(newPos, argType, mode, func);
                     } else {
                         var arg = this.parseGroup(newPos, mode);
                     }
@@ -428,7 +428,7 @@ Parser.prototype.parseFunction = function(pos, mode) {
  *
  * @return {?ParseFuncOrArgument}
  */
-Parser.prototype.parseSpecialGroup = function(pos, mode, outerMode) {
+Parser.prototype.parseSpecialGroup = function(pos, mode, outerMode, funcName) {
     if (mode === "color" || mode === "size") {
         // color and size modes are special because they should have braces and
         // should only lex a single symbol inside
@@ -449,14 +449,18 @@ Parser.prototype.parseSpecialGroup = function(pos, mode, outerMode) {
         return this.parseGroup(whitespace.position, mode);
     } else if (mode === "math") {
         return this.parseGroup(pos, mode);
-    } else {
+    } else if (funcName !== undefined) {
         for (var i = 0; i < extensions.exts.length; i++) {
             var ext = extensions.exts[i];
-            if (ext.mode === mode && ext.parseSpecialGroup) {
+            if (ext.funcs.hasOwnProperty(funcName) && ext.parseSpecialGroup) {
                 return ext.parseSpecialGroup.call(this, pos, mode, outerMode);
             }
         }
+        throw new ParseError("can't parse argType '" + mode + "' for function" +
+            "'" + funcName + "'", this.lexer, pos);
     }
+    throw new ParseError("can't parse special group of mode '" + mode + "'",
+        this.lexer, pos);
 };
 
 /**

--- a/src/Token.js
+++ b/src/Token.js
@@ -1,0 +1,8 @@
+// The resulting token returned from `lex`.
+function Token(type, text, position) {
+    this.type = type;
+    this.text = text;
+    this.position = position;
+}
+
+module.exports = Token;

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -105,6 +105,22 @@ var makeSpan = function(classes, children, color) {
     return span;
 };
 
+// TODO: combine with makeSpan and make third param be an options dictionary?
+/**
+ * Makes a span with the given list of classes, list of children, and id.
+ */
+var makeSpanWithId = function(classes, children, id) {
+    var span = new domTree.span(classes, children);
+
+    sizeElementFromChildren(span);
+
+    if (id) {
+        span.id = id;
+    }
+
+    return span;
+};
+
 /**
  * Makes a document fragment with the given list of children.
  */
@@ -264,6 +280,7 @@ module.exports = {
     mathit: mathit,
     mathrm: mathrm,
     makeSpan: makeSpan,
+    makeSpanWithId: makeSpanWithId,
     makeFragment: makeFragment,
     makeVList: makeVList
 };

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -81,6 +81,8 @@ var getTypeOfGroup = function(group) {
         return getTypeOfGroup(group.value);
     } else if (group.type === "color") {
         return getTypeOfGroup(group.value.value);
+    } else if (group.type === "cssId") {
+        return getTypeOfGroup(group.value.value);
     } else if (group.type === "sizing") {
         return getTypeOfGroup(group.value.value);
     } else if (group.type === "styling") {
@@ -127,6 +129,12 @@ var getBaseElem = function(group) {
             return group;
         }
     } else if (group.type === "color") {
+        if (group.value.value.length === 1) {
+            return getBaseElem(group.value.value[0]);
+        } else {
+            return group;
+        }
+    } else if (group.type === "cssId") {
         if (group.value.value.length === 1) {
             return getBaseElem(group.value.value[0]);
         } else {
@@ -243,6 +251,27 @@ var groupTypes = {
         // elements will be able to directly interact with their neighbors. For
         // example, `\color{red}{2 +} 3` has the same spacing as `2 + 3`
         return new buildCommon.makeFragment(elements);
+    },
+
+    cssId: function(group, options, prev) {
+        var elements = buildExpression(
+            group.value.value,
+            options,
+            prev
+        );
+
+        if (elements.length === 1) {
+            elements[0].id = group.value.id;
+            return elements[0];
+        } else {
+            var classes = [];
+            if (elements.length > 1) {
+                var lastChild = elements[elements.length - 1];
+                classes = lastChild.classes.slice(0);
+            }
+            classes.push(options.style.cls());
+            return buildCommon.makeSpanWithId(classes, elements, group.value.id);
+        }
     },
 
     supsub: function(group, options, prev) {

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -13,7 +13,6 @@ var buildCommon = require("./buildCommon");
 var delimiter = require("./delimiter");
 var domTree = require("./domTree");
 var fontMetrics = require("./fontMetrics");
-var parseTree = require("./parseTree");
 var symbols = require("./symbols");
 var utils = require("./utils");
 
@@ -251,27 +250,6 @@ var groupTypes = {
         // elements will be able to directly interact with their neighbors. For
         // example, `\color{red}{2 +} 3` has the same spacing as `2 + 3`
         return new buildCommon.makeFragment(elements);
-    },
-
-    cssId: function(group, options, prev) {
-        var elements = buildExpression(
-            group.value.value,
-            options,
-            prev
-        );
-
-        if (elements.length === 1) {
-            elements[0].id = group.value.id;
-            return elements[0];
-        } else {
-            var classes = [];
-            if (elements.length > 1) {
-                var lastChild = elements[elements.length - 1];
-                classes = lastChild.classes.slice(0);
-            }
-            classes.push(options.style.cls());
-            return buildCommon.makeSpanWithId(classes, elements, group.value.id);
-        }
     },
 
     supsub: function(group, options, prev) {
@@ -1125,4 +1103,9 @@ var buildTree = function(tree) {
     return katexNode;
 };
 
-module.exports = buildTree;
+module.exports = {
+    buildTree: buildTree,
+    buildGroup: buildGroup,
+    buildExpression: buildExpression,
+    groupTypes: groupTypes
+};

--- a/src/delimiter.js
+++ b/src/delimiter.js
@@ -20,14 +20,11 @@
  * used in `\left` and `\right`.
  */
 
-var Options = require("./Options");
 var ParseError = require("./ParseError");
 var Style = require("./Style");
 
 var buildCommon = require("./buildCommon");
-var domTree = require("./domTree");
 var fontMetrics = require("./fontMetrics");
-var parseTree = require("./parseTree");
 var symbols = require("./symbols");
 var utils = require("./utils");
 

--- a/src/domTree.js
+++ b/src/domTree.js
@@ -58,6 +58,10 @@ span.prototype.toNode = function() {
         span.appendChild(this.children[i].toNode());
     }
 
+    if (this.id) {
+        span.setAttribute("id", this.id);
+    }
+
     return span;
 };
 
@@ -72,6 +76,10 @@ span.prototype.toMarkup = function() {
         markup += " class=\"";
         markup += utils.escape(createClass(this.classes));
         markup += "\"";
+    }
+
+    if (this.id) {
+        markup += " id=\"" + this.id + "\"";
     }
 
     var styles = "";
@@ -182,6 +190,10 @@ symbolNode.prototype.toNode = function() {
         }
     }
 
+    if (this.id) {
+        span.setAttribute("id", this.id);
+    }
+
     if (span) {
         span.appendChild(node);
         return span;
@@ -205,6 +217,10 @@ symbolNode.prototype.toMarkup = function() {
         markup += " class=\"";
         markup += utils.escape(createClass(this.classes));
         markup += "\"";
+    }
+
+    if (this.id) {
+        markup += " id=\"" + this.id + "\"";
     }
 
     var styles = "";

--- a/src/ext/css_ext.js
+++ b/src/ext/css_ext.js
@@ -12,37 +12,40 @@ var buildExpression = buildTree.buildExpression;
 var cssIdRegex = /^([a-z\-\_][a-z0-9\-\_]*)/i;
 var whitespaceRegex = /^\s*/;
 
+function cssLexer (pos) {
+    var input = this._input.slice(pos);
+
+    // Ignore whitespace
+    var whitespace = input.match(whitespaceRegex)[0];
+    pos += whitespace.length;
+    input = input.slice(whitespace.length);
+
+    var match;
+    if ((match = input.match(cssIdRegex))) {
+        return new Token("cssId", match[0], pos + match[0].length);
+    } else {
+        throw new ParseError("Invalid id", this, pos);
+    }
+}
+
 var CssExtension = {
-    // TODO: make "modes" a list of mode objects which this extension provides
-    // each "mode" object contains a lexer and a parseSpecialGroup parser
-    mode: "css", // used for both \class and \cssId
-    lexer: function (pos) {
-        var input = this._input.slice(pos);
-
-        // Ignore whitespace
-        var whitespace = input.match(whitespaceRegex)[0];
-        pos += whitespace.length;
-        input = input.slice(whitespace.length);
-
-        var match;
-        if ((match = input.match(cssIdRegex))) {
-            return new Token("cssId", match[0], pos + match[0].length);
-        } else {
-            throw new ParseError("Invalid id", this, pos);
-        }
-    },
-    // Note: mode = argType
     parseSpecialGroup: function (pos, mode, outerMode) {
-        var openBrace = this.lexer.lex(pos, outerMode);
-        this.expect(openBrace, "{");
-        var inner = this.lexer.lex(openBrace.position, mode);
-        var closeBrace = this.lexer.lex(inner.position, outerMode);
-        this.expect(closeBrace, "}");
-        return new ParseFuncOrArgument(
-            new ParseResult(
-                new ParseNode("color", inner.text, outerMode),
-                closeBrace.position),
-            false);
+        if (mode === "css") {
+            var openBrace = this.lexer.lex(pos, outerMode);
+            this.expect(openBrace, "{");
+            var inner = this.lexer.lex(openBrace.position, cssLexer);
+            var closeBrace = this.lexer.lex(inner.position, outerMode);
+            this.expect(closeBrace, "}");
+
+            return new ParseFuncOrArgument(
+                new ParseResult(
+                    new ParseNode("css", inner.text, outerMode),
+                    closeBrace.position),
+                false);
+        } else {
+            throw new ParseError("this extension can't parse '" + mode + "'" +
+                "arguments", this.lexer, pos);
+        }
     },
     funcs: {
         "\\cssId": {

--- a/src/ext/css_ext.js
+++ b/src/ext/css_ext.js
@@ -33,7 +33,8 @@ var CssExtension = {
         if (mode === "css") {
             var openBrace = this.lexer.lex(pos, outerMode);
             this.expect(openBrace, "{");
-            var inner = this.lexer.lex(openBrace.position, cssLexer);
+            var inner = this.lexer.lexWithCustomLexer(
+                openBrace.position, cssLexer);
             var closeBrace = this.lexer.lex(inner.position, outerMode);
             this.expect(closeBrace, "}");
 

--- a/src/ext/css_ext.js
+++ b/src/ext/css_ext.js
@@ -1,0 +1,132 @@
+var Token = require("./../Token");
+var ParseError = require("./../ParseError");
+var Parser = require("./../Parser");
+var buildTree = require("./../buildTree");
+var buildCommon = require("./../buildCommon");
+
+var ParseNode = Parser.ParseNode;
+var ParseResult = Parser.ParseResult;
+var ParseFuncOrArgument = Parser.ParseFuncOrArgument;
+var buildExpression = buildTree.buildExpression;
+
+var cssIdRegex = /^([a-z\-\_][a-z0-9\-\_]*)/i;
+var whitespaceRegex = /^\s*/;
+
+var CssExtension = {
+    // TODO: make "modes" a list of mode objects which this extension provides
+    // each "mode" object contains a lexer and a parseSpecialGroup parser
+    mode: "css", // used for both \class and \cssId
+    lexer: function (pos) {
+        var input = this._input.slice(pos);
+
+        // Ignore whitespace
+        var whitespace = input.match(whitespaceRegex)[0];
+        pos += whitespace.length;
+        input = input.slice(whitespace.length);
+
+        var match;
+        if ((match = input.match(cssIdRegex))) {
+            return new Token("cssId", match[0], pos + match[0].length);
+        } else {
+            throw new ParseError("Invalid id", this, pos);
+        }
+    },
+    // Note: mode = argType
+    parseSpecialGroup: function (pos, mode, outerMode) {
+        var openBrace = this.lexer.lex(pos, outerMode);
+        this.expect(openBrace, "{");
+        var inner = this.lexer.lex(openBrace.position, mode);
+        var closeBrace = this.lexer.lex(inner.position, outerMode);
+        this.expect(closeBrace, "}");
+        return new ParseFuncOrArgument(
+            new ParseResult(
+                new ParseNode("color", inner.text, outerMode),
+                closeBrace.position),
+            false);
+    },
+    funcs: {
+        "\\cssId": {
+            numArgs: 2,
+            argTypes: ["css", "original"],
+            handler: function(func, id, body) {
+                // Normalize the different kinds of bodies (see \text above)
+                var inner;
+                if (body.type === "ordgroup") {
+                    inner = body.value;
+                } else {
+                    inner = [body];
+                }
+
+                return {
+                    type: "cssId",
+                    id: id.value,
+                    value: inner
+                };
+            }
+        },
+        "\\class": {
+            numArgs: 2,
+            argTypes: ["css", "original"],
+            handler: function(func, id, body) {
+                // Normalize the different kinds of bodies (see \text above)
+                var inner;
+                if (body.type === "ordgroup") {
+                    inner = body.value;
+                } else {
+                    inner = [body];
+                }
+
+                return {
+                    type: "class",
+                    className: id.value,
+                    value: inner
+                };
+            }
+        }
+    },
+    groupTypes: {
+        cssId: function(group, options, prev) {
+            var elements = buildExpression(
+                group.value.value,
+                options,
+                prev
+            );
+
+            if (elements.length === 1) {
+                elements[0].id = group.value.id;
+                return elements[0];
+            } else {
+                var classes = [];
+                if (elements.length > 1) {
+                    var lastChild = elements[elements.length - 1];
+                    classes = lastChild.classes.slice(0);
+                }
+                classes.push(options.style.cls());
+                return buildCommon.makeSpanWithId(classes, elements, group.value.id);
+            }
+        },
+        "class": function(group, options, prev) {
+            var elements = buildExpression(
+                group.value.value,
+                options,
+                prev
+            );
+
+            if (elements.length === 1) {
+                elements[0].classes.push(group.value.className);
+                return elements[0];
+            } else {
+                var classes = [];
+                if (elements.length > 1) {
+                    var lastChild = elements[elements.length - 1];
+                    classes = lastChild.classes.slice(0);
+                }
+                classes.push(options.style.cls());
+                classes.push(group.value.className);
+                return buildCommon.makeSpan(classes, elements);
+            }
+        }
+    }
+};
+
+module.exports = CssExtension;

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -1,0 +1,37 @@
+// modules implementing an extension should require this module and push their
+// extension on exts.
+
+var functions = require("./functions");
+var buildTree = require("./buildTree");
+
+var extensions = [];
+
+/**
+ * Registers an extension by copy entries to functions.funcs and
+ * buildTree.groupTypes.
+ *
+ * @param extension
+ */
+function register(extension) {
+    // copy functions from the extension into the global "functions" dictionary
+    Object.keys(extension.funcs).forEach(function (funcName) {
+        if (!functions.hasOwnProperty(funcName)) {
+            functions.funcs[funcName] = extension.funcs[funcName];
+        } else {
+            throw Error("extension tried to overwrite existing function");
+        }
+    });
+
+    Object.keys(extension.groupTypes).forEach(function (groupName) {
+        if (!buildTree.groupTypes.hasOwnProperty(groupName)) {
+            buildTree.groupTypes[groupName] = extension.groupTypes[groupName];
+        }
+    });
+
+    extensions.push(extension);
+}
+
+module.exports = {
+    exts: extensions,
+    register: register
+};

--- a/src/functions.js
+++ b/src/functions.js
@@ -118,6 +118,26 @@ var functions = {
         }
     },
 
+    "\\cssId": {
+        numArgs: 2,
+        argTypes: ["cssId", "original"],
+        handler: function(func, id, body) {
+            // Normalize the different kinds of bodies (see \text above)
+            var inner;
+            if (body.type === "ordgroup") {
+                inner = body.value;
+            } else {
+                inner = [body];
+            }
+
+            return {
+                type: "cssId",
+                id: id.value,
+                value: inner
+            };
+        }
+    },
+
     // An overline
     "\\overline": {
         numArgs: 1,

--- a/src/functions.js
+++ b/src/functions.js
@@ -118,26 +118,6 @@ var functions = {
         }
     },
 
-    "\\cssId": {
-        numArgs: 2,
-        argTypes: ["cssId", "original"],
-        handler: function(func, id, body) {
-            // Normalize the different kinds of bodies (see \text above)
-            var inner;
-            if (body.type === "ordgroup") {
-                inner = body.value;
-            } else {
-                inner = [body];
-            }
-
-            return {
-                type: "cssId",
-                id: id.value,
-                value: inner
-            };
-        }
-    },
-
     // An overline
     "\\overline": {
         numArgs: 1,

--- a/src/parseTree.js
+++ b/src/parseTree.js
@@ -9,9 +9,9 @@ var Parser = require("./Parser");
  * Parses an expression using a Parser, then returns the parsed result.
  */
 var parseTree = function(toParse) {
-    var parser = new Parser(toParse);
+    var parser = new Parser.Parser(toParse);
 
     return parser.parse();
-}
+};
 
 module.exports = parseTree;

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -586,6 +586,93 @@ describe("A color parser", function() {
     });
 });
 
+describe("A cssId parser", function () {
+    var cssIdExpressionWithGroup = "\\cssId{_id_1-a}{1+2}";
+    var cssIdExpressionWithAtom = "\\cssId{id_1-a}\\frac{1}{x}";
+    var badCssIdExpression = "\\cssId{\\theta}{1+2}";
+
+    it("should not fail", function () {
+        expect(cssIdExpressionWithGroup).toParse();
+        expect(cssIdExpressionWithAtom).toParse();
+    });
+
+    it("should build a cssId node", function () {
+        var node = parseTree(cssIdExpressionWithGroup)[0];
+
+        expect(node.type).toMatch("cssId");
+        expect(node.value.id).toMatch("_id_1-a");
+        expect(node.value.value).toBeDefined();
+    });
+
+    it("should parse a group body", function () {
+        var node = parseTree(cssIdExpressionWithGroup)[0];
+
+        var inner = node.value.value;
+        expect(inner.length).toBe(3);
+        expect(inner[0].type).toMatch("textord");
+        expect(inner[1].type).toMatch("bin");
+        expect(inner[2].type).toMatch("textord");
+    });
+
+    it("should parse an atom body", function () {
+        var node = parseTree(cssIdExpressionWithAtom)[0];
+
+        var inner = node.value.value;
+        expect(inner.length).toBe(1);
+        expect(inner[0].type).toMatch("frac");
+    });
+
+    it("should not parse a id", function () {
+        expect(badCssIdExpression).toNotParse();
+    });
+});
+
+describe("A cssId tree-builder", function () {
+    it("should render a number with an id", function () {
+        var tree = parseTree("\\cssId{id1}{1}");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render a symbol with an id", function () {
+        var tree = parseTree("\\cssId{id1}\\pi");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render a variable with an id", function () {
+        var tree = parseTree("\\cssId{id1}x");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render an operator with an id", function () {
+        var tree = parseTree("\\cssId{id1}+");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render a relationship with an id", function () {
+        var tree = parseTree("\\cssId{id1}>");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="id1"')).not.toBe(-1);
+    });
+
+    it("should render the numerator and denomator with different ids", function () {
+        var tree = parseTree("\\frac{\\cssId{numer}{x}}{\\cssId{denom}{x+1}}");
+        var markup = buildTree(tree).toMarkup();
+        expect(markup.indexOf('id="numer"')).not.toBe(-1);
+        expect(markup.indexOf('id="denom"')).not.toBe(-1);
+    });
+
+    it("should render a function with unique id and not its children", function () {
+        var tree = parseTree("\\cssId{id1}{\\frac{x}{x+1}}");
+        var markup = buildTree(tree).toMarkup();
+        var matches = markup.match(/id="id1"/g);
+        expect(matches.length).toBe(1);
+    });
+});
+
 describe("A tie parser", function() {
     var mathTie = "a~b";
     var textTie = "\\text{a~ b}";

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3,6 +3,8 @@ var buildTree = require("../src/buildTree");
 var parseTree = require("../src/parseTree");
 var ParseError = require("../src/ParseError");
 
+buildTree = buildTree.buildTree;
+
 var getBuilt = function(expr) {
     expect(expr).toBuild();
 
@@ -670,6 +672,37 @@ describe("A cssId tree-builder", function () {
         var markup = buildTree(tree).toMarkup();
         var matches = markup.match(/id="id1"/g);
         expect(matches.length).toBe(1);
+    });
+});
+
+describe("A class parser", function () {
+    var classExpressionWithGroup = "\\class{sum}{1+2}, \\class{sum}{3+4}";
+    var badClassExpression = "\\class{\\theta}{1+2}";
+
+    it("should not fail", function () {
+        expect(classExpressionWithGroup).toParse();
+    });
+
+    it("should build a class node", function () {
+        var node = parseTree(classExpressionWithGroup)[0];
+
+        expect(node.type).toMatch("class");
+        expect(node.value.className).toMatch("sum");
+        expect(node.value.value).toBeDefined();
+    });
+
+    it("should parse a group body", function () {
+        var node = parseTree(classExpressionWithGroup)[0];
+
+        var inner = node.value.value;
+        expect(inner.length).toBe(3);
+        expect(inner[0].type).toMatch("textord");
+        expect(inner[1].type).toMatch("bin");
+        expect(inner[2].type).toMatch("textord");
+    });
+
+    it("should not parse a bad class", function () {
+        expect(badClassExpression).toNotParse();
     });
 });
 


### PR DESCRIPTION
This is just an experiment to see what extensions might look like and also to get a better understanding of all the nooks and crannies of the problem.  This is based on a suggestion from @xymostech in issue https://github.com/Khan/KaTeX/issues/90.