### PR TITLE
The Big Symbols PR

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -17,6 +17,1760 @@
 
 var symbols = {
     "math": {
+        // Non-ASCII
+        "\\aa": {
+            font: "main",
+            group: "textord",
+            replace: "\u00e5"
+        },
+        "\\AA": {
+            font: "main",
+            group: "textord",
+            replace: "\u00c5"
+        },
+        "\\AE": {
+            font: "main",
+            group: "textord",
+            replace: "\u00c6"
+        },
+        "\\ae": {
+            font: "main",
+            group: "textord",
+            replace: "\u00e6"
+        },
+        "\\L": {
+            font: "main",
+            group: "textord",
+            replace: "\u0141"
+        },
+        "\\l": {
+            font: "main",
+            group: "textord",
+            replace: "\u0142"
+        },
+        "\\o": {
+            font: "main",
+            group: "textord",
+            replace: "\u00f8"
+        },
+        "\\O": {
+            font: "main",
+            group: "textord",
+            replace: "\u00d8"
+        },
+        "\\OE": {
+            font: "main",
+            group: "textord",
+            replace: "\u0152"
+        },
+        "\\oe": {
+            font: "main",
+            group: "textord",
+            replace: "\u0153"
+        },
+        "\\ss": {
+            font: "main",
+            group: "textord",
+            replace: "\u00df"
+        },
+        "\\SS": {
+            font: "main",
+            group: "textord",
+            replace: "SS"
+        },
+
+        // Relation Symbols
+        "\\equiv": {
+            font: "main",
+            group: "rel",
+            replace: "\u2261"
+        },
+        "\\models": {
+            font: "main",
+            group: "rel",
+            replace: "\u22a8"
+        },
+        "\\prec": {
+            font: "main",
+            group: "rel",
+            replace: "\u227a"
+        },
+        "\\succ": {
+            font: "main",
+            group: "rel",
+            replace: "\u227b"
+        },
+        "\\sim": {
+            font: "main",
+            group: "rel",
+            replace: "\u223c"
+        },
+        "\\perp": {
+            font: "main",
+            group: "rel",
+            replace: "\u22a5"
+        },
+        "\\preceq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2aaf"
+        },
+        "\\succeq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2ab0"
+        },
+        "\\simeq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2243"
+        },
+        "\\mid": {
+            font: "main",
+            group: "rel",
+            replace: "\u2223"
+        },
+        "\\ll": {
+            font: "main",
+            group: "rel",
+            replace: "\u226a"
+        },
+        "\\gg": {
+            font: "main",
+            group: "rel",
+            replace: "\u226b"
+        },
+        "\\asymp": {
+            font: "main",
+            group: "rel",
+            replace: "\u224d"
+        },
+        "\\parallel": {
+            font: "main",
+            group: "rel",
+            replace: "\u2225"
+        },
+        "\\subset": {
+            font: "main",
+            group: "rel",
+            replace: "\u2282"
+        },
+        "\\supset": {
+            font: "main",
+            group: "rel",
+            replace: "\u2283"
+        },
+        "\\bowtie": {
+            font: "main",
+            group: "rel",
+            replace: "\u22c8"
+        },
+        "\\subseteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2286"
+        },
+        "\\supseteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2287"
+        },
+        "\\smile": {
+            font: "main",
+            group: "rel",
+            replace: "\u2323"
+        },
+        "\\sqsubseteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2291"
+        },
+        "\\sqsupseteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2292"
+        },
+        "\\doteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2250"
+        },
+        "\\frown": {
+            font: "main",
+            group: "rel",
+            replace: "\u2322"
+        },
+        "\\ni": {
+            font: "main",
+            group: "rel",
+            replace: "\u220b"
+        },
+        "\\propto": {
+            font: "main",
+            group: "rel",
+            replace: "\u221d"
+        },
+        "\\vdash": {
+            font: "main",
+            group: "rel",
+            replace: "\u22a2"
+        },
+        "\\dashv": {
+            font: "main",
+            group: "rel",
+            replace: "\u22a3"
+        },
+        "\\owns": {
+            font: "main",
+            group: "rel",
+            replace: "\u220b"
+        },
+
+        // Punctuation
+        "\\ldotp": {
+            font: "main",
+            group: "punct",
+            replace: "\u002e"
+        },
+        "\\cdotp": {
+            font: "main",
+            group: "punct",
+            replace: "\u22c5"
+        },
+
+        // Misc Symbols
+        "\\aleph": {
+            font: "main",
+            group: "textord",
+            replace: "\u2135"
+        },
+        "\\forall": {
+            font: "main",
+            group: "textord",
+            replace: "\u2200"
+        },
+        "\\hbar": {
+            font: "main",
+            group: "textord",
+            replace: "\u210f"
+        },
+        "\\emptyset": {
+            font: "main",
+            group: "textord",
+            replace: "\u2205"
+        },
+        "\\exists": {
+            font: "main",
+            group: "textord",
+            replace: "\u2203"
+        },
+        "\\imath": {
+            font: "main",
+            group: "textord",
+            replace: "\u0131"
+        },
+        "\\nabla": {
+            font: "main",
+            group: "textord",
+            replace: "\u2207"
+        },
+        "\\neg": {
+            font: "main",
+            group: "textord",
+            replace: "\u00ac"
+        },
+        "\\jmath": {
+            font: "main",
+            group: "textord",
+            replace: "\u0237"
+        },
+        "\\flat": {
+            font: "main",
+            group: "textord",
+            replace: "\u266d"
+        },
+        "\\ell": {
+            font: "main",
+            group: "textord",
+            replace: "\u2113"
+        },
+        "\\top": {
+            font: "main",
+            group: "textord",
+            replace: "\u22a4"
+        },
+        "\\natural": {
+            font: "main",
+            group: "textord",
+            replace: "\u266e"
+        },
+        "\\clubsuit": {
+            font: "main",
+            group: "textord",
+            replace: "\u2663"
+        },
+        "\\wp": {
+            font: "main",
+            group: "textord",
+            replace: "\u2118"
+        },
+        "\\bot": {
+            font: "main",
+            group: "textord",
+            replace: "\u22a5"
+        },
+        "\\sharp": {
+            font: "main",
+            group: "textord",
+            replace: "\u266f"
+        },
+        "\\diamondsuit": {
+            font: "main",
+            group: "textord",
+            replace: "\u2662"
+        },
+        "\\Re": {
+            font: "main",
+            group: "textord",
+            replace: "\u211c"
+        },
+        "\\heartsuit": {
+            font: "main",
+            group: "textord",
+            replace: "\u2661"
+        },
+        "\\Im": {
+            font: "main",
+            group: "textord",
+            replace: "\u2111"
+        },
+        "\\partial": {
+            font: "main",
+            group: "textord",
+            replace: "\u2202"
+        },
+        "\\spadesuit": {
+            font: "main",
+            group: "textord",
+            replace: "\u2660"
+        },
+        "\\lnot": {
+            font: "main",
+            group: "textord",
+            replace: "\u00ac"
+        },
+
+        // Math and Text
+        "\\S": {
+            font: "main",
+            group: "textord",
+            replace: "\u00a7"
+        },
+        "\\copyright": {
+            font: "main",
+            group: "textord",
+            replace: "©"
+        },
+        "\\dag": {
+            font: "main",
+            group: "textord",
+            replace: "\u2020"
+        },
+        "\\ddag": {
+            font: "main",
+            group: "textord",
+            replace: "\u2021"
+        },
+        "\\dots": {
+            font: "main",
+            group: "textord",
+            replace: "…"
+        },
+        "\\pounds": {
+            font: "main",
+            group: "textord",
+            replace: "\u00a3"
+        },
+
+        // Large Delimiters
+        "\\rmoustache": {
+            font: "main",
+            group: "open",
+            replace: "\u23b1"
+        },
+        "\\lmoustache": {
+            font: "main",
+            group: "open",
+            replace: "\u23b0"
+        },
+        "\\rgroup": {
+            font: "main",
+            group: "open",
+            replace: "\u27ef"
+        },
+        "\\lgroup": {
+            font: "main",
+            group: "open",
+            replace: "\u27ee"
+        },
+        "\\arrowvert": {
+            font: "main",
+            group: "open",
+            replace: "\u23d0"
+        },
+        "\\Arrowvert": {
+            font: "main",
+            group: "open",
+            replace: "\u2016"
+        },
+        "\\bracevert": {
+            font: "main",
+            group: "open",
+            replace: "\u23aa"
+        },
+
+        // Binary Operators
+        "\\cap": {
+            font: "main",
+            group: "textord",
+            replace: "\u2229"
+        },
+        "\\mp": {
+            font: "main",
+            group: "textord",
+            replace: "\u2213"
+        },
+        "\\cup": {
+            font: "main",
+            group: "textord",
+            replace: "\u222a"
+        },
+        "\\ominus": {
+            font: "main",
+            group: "textord",
+            replace: "\u2296"
+        },
+        "\\uplus": {
+            font: "main",
+            group: "textord",
+            replace: "\u228e"
+        },
+        "\\sqcap": {
+            font: "main",
+            group: "textord",
+            replace: "\u2293"
+        },
+        "\\ast": {
+            font: "main",
+            group: "textord",
+            replace: "\u2217"
+        },
+        "\\sqcup": {
+            font: "main",
+            group: "textord",
+            replace: "\u2294"
+        },
+        "\\vee": {
+            font: "main",
+            group: "textord",
+            replace: "\u2228"
+        },
+        "\\bigcirc": {
+            font: "main",
+            group: "textord",
+            replace: "\u25ef"
+        },
+        "\\wedge": {
+            font: "main",
+            group: "textord",
+            replace: "\u2227"
+        },
+        "\\bullet": {
+            font: "main",
+            group: "textord",
+            replace: "\u2219"
+        },
+        "\\setminus": {
+            font: "main",
+            group: "textord",
+            replace: "\u2216"
+        },
+        "\\ddagger": {
+            font: "main",
+            group: "textord",
+            replace: "\u2021"
+        },
+        "\\wr": {
+            font: "main",
+            group: "textord",
+            replace: "\u2240"
+        },
+        "\\amalg": {
+            font: "main",
+            group: "textord",
+            replace: "\u2a3f"
+        },
+        "\\land": {
+            font: "main",
+            group: "textord",
+            replace: "\u2227"
+        },
+        "\\lor": {
+            font: "main",
+            group: "textord",
+            replace: "\u2228"
+        },
+
+        // Arrow Symbols
+        "\\longleftarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u27f5"
+        },
+        "\\Leftarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u21d0"
+        },
+        "\\Longleftarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u27f8"
+        },
+        "\\longrightarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u27f6"
+        },
+        "\\Rightarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u21d2"
+        },
+        "\\Longrightarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u27f9"
+        },
+        "\\leftrightarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u2194"
+        },
+        "\\longleftrightarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u27f7"
+        },
+        "\\Leftrightarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u21d4"
+        },
+        "\\Longleftrightarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u27fa"
+        },
+        "\\mapsto": {
+            font: "main",
+            group: "textord",
+            replace: "\u21a6"
+        },
+        "\\longmapsto": {
+            font: "main",
+            group: "textord",
+            replace: "\u27fc"
+        },
+        "\\nearrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u2197"
+        },
+        "\\hookleftarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u21a9"
+        },
+        "\\hookrightarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u21aa"
+        },
+        "\\searrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u2198"
+        },
+        "\\leftharpoonup": {
+            font: "main",
+            group: "textord",
+            replace: "\u21bc"
+        },
+        "\\rightharpoonup": {
+            font: "main",
+            group: "textord",
+            replace: "\u21c0"
+        },
+        "\\swarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u2199"
+        },
+        "\\leftharpoondown": {
+            font: "main",
+            group: "textord",
+            replace: "\u21bd"
+        },
+        "\\rightharpoondown": {
+            font: "main",
+            group: "textord",
+            replace: "\u21c1"
+        },
+        "\\nwarrow": {
+            font: "main",
+            group: "textord",
+            replace: "\u2196"
+        },
+        "\\rightleftharpoons": {
+            font: "main",
+            group: "textord",
+            replace: "\u21cc"
+        },
+
+        // AMS Negated Binary Relations
+        "\\nless": {
+            font: "ams",
+            group: "rel",
+            replace: "\u226e"
+        },
+        "\\nleqslant": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a87"
+        },
+        "\\nleqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2270"
+        },
+        "\\lneq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a87"
+        },
+        "\\lneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2268"
+        },
+        "\\lvertneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2268"
+        },
+        "\\lnsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22e6"
+        },
+        "\\lnapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a89"
+        },
+        "\\nprec": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2280"
+        },
+        "\\npreceq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22e0"
+        },
+        "\\precnsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22e8"
+        },
+        "\\precnapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2ab9"
+        },
+        "\\nsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2241"
+        },
+        "\\nshortmid": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2224"
+        },
+        "\\nmid": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2224"
+        },
+        "\\nvdash": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22ac"
+        },
+        "\\nvDash": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22ad"
+        },
+        "\\ntriangleleft": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22ea"
+        },
+        "\\ntrianglelefteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22ec"
+        },
+        "\\nsubseteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2288"
+        },
+        "\\subsetneq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u228a"
+        },
+        "\\varsubsetneq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u228a"
+        },
+        "\\subsetneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2acb"
+        },
+        "\\varsubsetneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2acb"
+        },
+        "\\ngtr": {
+            font: "ams",
+            group: "rel",
+            replace: "\u226f"
+        },
+        "\\ngeqslant": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a88"
+        },
+        "\\ngeqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2271"
+        },
+        "\\gneq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a88"
+        },
+        "\\gneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2269"
+        },
+        "\\gvertneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2269"
+        },
+        "\\gnsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22e7"
+        },
+        "\\gnapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a8a"
+        },
+        "\\nsucc": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2281"
+        },
+        "\\nsucceq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22e1"
+        },
+        "\\succnsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22e9"
+        },
+        "\\succnapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2aba"
+        },
+        "\\ncong": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2246"
+        },
+        "\\nshortparallel": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2226"
+        },
+        "\\nparallel": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2226"
+        },
+        "\\nVDash": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22af"
+        },
+        "\\ntriangleright": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22eb"
+        },
+        "\\ntrianglerighteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22ed"
+        },
+        "\\nsupseteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2289"
+        },
+        "\\nsupseteqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2289"
+        },
+        "\\supsetneq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u228b"
+        },
+        "\\varsupsetneq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u228b"
+        },
+        "\\supsetneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2acc"
+        },
+        "\\varsupsetneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2acc"
+        },
+        "\\unlhd": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22b4"
+        },
+        "\\unrhd": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22b5"
+        },
+        "\\nVdash": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22ae"
+        },
+        "\\precneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2ab5"
+        },
+        "\\succneqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2ab6"
+        },
+        "\\nsubseteqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2288"
+        },
+
+        // AMS Negated Arrows
+         "\\nleftarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u219a"
+        },
+        "\\nrightarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u219b"
+        },
+        "\\nLeftarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21cd"
+        },
+        "\\nRightarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21cf"
+        },
+        "\\nleftrightarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21ae"
+        },
+        "\\nLeftrightarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21ce"
+        },
+
+        // AMS Misc
+        "\\hslash": {
+            font: "ams",
+            group: "textord",
+            replace: "\u210f"
+        },
+        "\\vartriangle": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25b3"
+        },
+        "\\triangledown": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25bd"
+        },
+        "\\lozenge": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25ca"
+        },
+        "\\circledS": {
+            font: "ams",
+            group: "textord",
+            replace: "\u24c8"
+        },
+        "\\measuredangle": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2221"
+        },
+        "\\nexists": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2204"
+        },
+        "\\mho": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2127"
+        },
+        "\\Finv": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2132"
+        },
+        "\\Game": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2141"
+        },
+        "\\Bbbk": {
+            font: "ams",
+            group: "textord",
+            replace: "\u006b"
+        },
+        "\\backprime": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2035"
+        },
+        "\\varnothing": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2205"
+        },
+        "\\blacktriangle": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25b4"
+        },
+        "\\blacktriangledown": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25be"
+        },
+        "\\blacksquare": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25fc"
+        },
+        "\\blacklozenge": {
+            font: "ams",
+            group: "textord",
+            replace: "\u29eb"
+        },
+        "\\bigstar": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2605"
+        },
+        "\\sphericalangle": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2222"
+        },
+        "\\complement": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2201"
+        },
+        "\\eth": {
+            font: "ams",
+            group: "textord",
+            replace: "\u00f0"
+        },
+        "\\diagup": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2571"
+        },
+        "\\diagdown": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2572"
+        },
+        "\\square": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25fb"
+        },
+        "\\Box": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25fb"
+        },
+        "\\Diamond": {
+            font: "ams",
+            group: "textord",
+            replace: "\u25ca"
+        },
+        "\\yen": {
+            font: "ams",
+            group: "textord",
+            replace: "\u00a5"
+        },
+
+        // AMS Hebrew
+        "\\beth": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2136"
+        },
+        "\\daleth": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2138"
+        },
+        "\\gimel": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2137"
+        },
+
+        // AMS Greek
+        "\\digamma": {
+            font: "ams",
+            group: "textord",
+            replace: "\u03dd"
+        },
+        "\\varkappa": {
+            font: "ams",
+            group: "textord",
+            replace: "\u03f0"
+        },
+
+        // AMS Delimiters
+        "\\ulcorner": {
+            font: "ams",
+            group: "textord",
+            replace: "\u231c"
+        },
+        "\\urcorner": {
+            font: "ams",
+            group: "textord",
+            replace: "\u231d"
+        },
+        "\\llcorner": {
+            font: "ams",
+            group: "textord",
+            replace: "\u231e"
+        },
+        "\\lrcorner": {
+            font: "ams",
+            group: "textord",
+            replace: "\u231f"
+        },
+
+        // AMS Binary Relations
+        "\\leqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2266"
+        },
+        "\\leqslant": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a7d"
+        },
+        "\\eqslantless": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a95"
+        },
+        "\\lesssim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2272"
+        },
+        "\\lessapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a85"
+        },
+        "\\approxeq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u224a"
+        },
+        "\\lessdot": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d6"
+        },
+        "\\lll": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d8"
+        },
+        "\\lessgtr": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2276"
+        },
+        "\\lesseqgtr": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22da"
+        },
+        "\\lesseqqgtr": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a8b"
+        },
+        "\\doteqdot": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2251"
+        },
+        "\\risingdotseq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2253"
+        },
+        "\\fallingdotseq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2252"
+        },
+        "\\backsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u223d"
+        },
+        "\\backsimeq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22cd"
+        },
+        "\\subseteqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2ac5"
+        },
+        "\\Subset": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d0"
+        },
+        "\\sqsubset": {
+            font: "ams",
+            group: "rel",
+            replace: "\u228f"
+        },
+        "\\preccurlyeq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u227c"
+        },
+        "\\curlyeqprec": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22de"
+        },
+        "\\precsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u227e"
+        },
+        "\\precapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2ab7"
+        },
+        "\\vartriangleleft": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22b2"
+        },
+        "\\trianglelefteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22b4"
+        },
+        "\\vDash": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22a8"
+        },
+        "\\Vvdash": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22aa"
+        },
+        "\\smallsmile": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2323"
+        },
+        "\\smallfrown": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2322"
+        },
+        "\\bumpeq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u224f"
+        },
+        "\\Bumpeq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u224e"
+        },
+        "\\geqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2267"
+        },
+        "\\geqslant": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a7e"
+        },
+        "\\eqslantgtr": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a96"
+        },
+        "\\gtrsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2273"
+        },
+        "\\gtrapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a86"
+        },
+        "\\gtrdot": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d7"
+        },
+        "\\ggg": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d9"
+        },
+        "\\gtrless": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2277"
+        },
+        "\\gtreqless": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22db"
+        },
+        "\\gtreqqless": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2a8c"
+        },
+        "\\eqcirc": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2256"
+        },
+        "\\circeq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2257"
+        },
+        "\\triangleq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u225c"
+        },
+        "\\thicksim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u223c"
+        },
+        "\\thickapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2248"
+        },
+        "\\supseteqq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2ac6"
+        },
+        "\\Supset": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d1"
+        },
+        "\\sqsupset": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2290"
+        },
+        "\\succcurlyeq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u227d"
+        },
+        "\\curlyeqsucc": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22df"
+        },
+        "\\succsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u227f"
+        },
+        "\\succapprox": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2ab8"
+        },
+        "\\vartriangleright": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22b3"
+        },
+        "\\trianglerighteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22b5"
+        },
+        "\\Vdash": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22a9"
+        },
+        "\\shortmid": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2223"
+        },
+        "\\shortparallel": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2225"
+        },
+        "\\between": {
+            font: "ams",
+            group: "rel",
+            replace: "\u226c"
+        },
+        "\\pitchfork": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d4"
+        },
+        "\\varpropto": {
+            font: "ams",
+            group: "rel",
+            replace: "\u221d"
+        },
+        "\\blacktriangleleft": {
+            font: "ams",
+            group: "rel",
+            replace: "\u25c2"
+        },
+        "\\therefore": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2234"
+        },
+        "\\backepsilon": {
+            font: "ams",
+            group: "rel",
+            replace: "\u220d"
+        },
+        "\\blacktriangleright": {
+            font: "ams",
+            group: "rel",
+            replace: "\u25b8"
+        },
+        "\\because": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2235"
+        },
+        "\\llless": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d8"
+        },
+        "\\gggtr": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22d9"
+        },
+        "\\lhd": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22b2"
+        },
+        "\\rhd": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22b3"
+        },
+        "\\eqsim": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2242"
+        },
+        "\\Join": {
+            font: "ams",
+            group: "rel",
+            replace: "\u22c8"
+        },
+        "\\Doteq": {
+            font: "ams",
+            group: "rel",
+            replace: "\u2251"
+        },
+
+        // AMS Binary Operators
+        "\\dotplus": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2214"
+        },
+        "\\smallsetminus": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2216"
+        },
+        "\\Cap": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22d2"
+        },
+        "\\Cup": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22d3"
+        },
+        "\\doublebarwedge": {
+            font: "ams",
+            group: "textord",
+            replace: "\u2a5e"
+        },
+        "\\boxminus": {
+            font: "ams",
+            group: "textord",
+            replace: "\u229f"
+        },
+        "\\boxplus": {
+            font: "ams",
+            group: "textord",
+            replace: "\u229e"
+        },
+        "\\divideontimes": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22c7"
+        },
+        "\\ltimes": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22c9"
+        },
+        "\\rtimes": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22ca"
+        },
+        "\\leftthreetimes": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22cb"
+        },
+        "\\rightthreetimes": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22cc"
+        },
+        "\\curlywedge": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22cf"
+        },
+        "\\curlyvee": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22ce"
+        },
+        "\\circleddash": {
+            font: "ams",
+            group: "textord",
+            replace: "\u229d"
+        },
+        "\\circledast": {
+            font: "ams",
+            group: "textord",
+            replace: "\u229b"
+        },
+        "\\centerdot": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22c5"
+        },
+        "\\intercal": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22ba"
+        },
+        "\\doublecap": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22d2"
+        },
+        "\\doublecup": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22d3"
+        },
+        "\\boxtimes": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22a0"
+        },
+
+        // AMS Arrows
+        "\\dashrightarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21e2"
+        },
+        "\\dashleftarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21e0"
+        },
+        "\\leftleftarrows": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21c7"
+        },
+        "\\leftrightarrows": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21c6"
+        },
+        "\\Lleftarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21da"
+        },
+        "\\twoheadleftarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u219e"
+        },
+        "\\leftarrowtail": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21a2"
+        },
+        "\\looparrowleft": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21ab"
+        },
+        "\\leftrightharpoons": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21cb"
+        },
+        "\\curvearrowleft": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21b6"
+        },
+        "\\circlearrowleft": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21ba"
+        },
+        "\\Lsh": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21b0"
+        },
+        "\\upuparrows": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21c8"
+        },
+        "\\upharpoonleft": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21bf"
+        },
+        "\\downharpoonleft": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21c3"
+        },
+        "\\multimap": {
+            font: "ams",
+            group: "textord",
+            replace: "\u22b8"
+        },
+        "\\leftrightsquigarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21ad"
+        },
+        "\\rightrightarrows": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21c9"
+        },
+        "\\rightleftarrows": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21c4"
+        },
+        "\\twoheadrightarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21a0"
+        },
+        "\\rightarrowtail": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21a3"
+        },
+        "\\looparrowright": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21ac"
+        },
+        "\\curvearrowright": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21b7"
+        },
+        "\\circlearrowright": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21bb"
+        },
+        "\\Rsh": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21b1"
+        },
+        "\\downdownarrows": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21ca"
+        },
+        "\\upharpoonright": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21be"
+        },
+        "\\downharpoonright": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21c2"
+        },
+        "\\rightsquigarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21dd"
+        },
+        "\\leadsto": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21dd"
+        },
+        "\\Rrightarrow": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21db"
+        },
+        "\\rightleftharpoons": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21cc"
+        },
+        "\\restriction": {
+            font: "ams",
+            group: "textord",
+            replace: "\u21be"
+        },
+        
         "`": {
             font: "main",
             group: "textord",


### PR DESCRIPTION
#### [View the symbols here](http://jmeas.com/katex-symbols/new/src/new.html)

– Adds [lots of new symbols](https://gist.github.com/jmeas/4e2b9df04b2e3a0dfe05)
– Organizes the new symbols
– Only new math symbols have been added
– Some metrics are missing (for now)

###### Future work

Right now it is not easy to add new symbols. I would recommend moving to a system where the symbols list is automatically generated from data lists, which is how I'm doing this PR.

======

`\P` is not be supported. [Ref.](https://github.com/mathjax/MathJax/issues/198#issuecomment-4261384) I tested in a browser and it came out as not-the-right-symbol.

=====

Resolves #62
Supersedes #57, #58, #81, #99, and part of #92