### PR TITLE
Add \LaTeX function

### DIFF
--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -672,6 +672,32 @@ var groupTypes = {
             ["katex-logo"], [k, a, t, e, x], options.getColor());
     },
 
+    latex: function(group, options, prev) {
+        // The LaTeX logo. Taken directly from KaTeX symbol, with K
+        // replaced with L.
+        var l = makeSpan(
+            ["l"], [buildCommon.mathrm("L", group.mode)]);
+        var a = makeSpan(
+            ["a"], [buildCommon.mathrm("A", group.mode)]);
+
+        a.height = (a.height + 0.2) * 0.75;
+        a.depth = (a.height - 0.2) * 0.75;
+
+        var t = makeSpan(
+            ["t"], [buildCommon.mathrm("T", group.mode)]);
+        var e = makeSpan(
+            ["e"], [buildCommon.mathrm("E", group.mode)]);
+
+        e.height = (e.height - 0.2155);
+        e.depth = (e.depth + 0.2155);
+
+        var x = makeSpan(
+            ["x"], [buildCommon.mathrm("X", group.mode)]);
+
+        return makeSpan(
+            ["latex-logo"], [l, a, t, e, x], options.getColor());
+    },
+
     overline: function(group, options, prev) {
         // Overlines are handled in the TeXbook pg 443, Rule 9.
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -152,6 +152,16 @@ var functions = {
         }
     },
 
+    // A LaTeX logo
+    "\\LaTeX": {
+        numArgs: 0,
+        handler: function(func) {
+            return {
+                type: "latex"
+            };
+        }
+    },
+
     "\\over": {
         numArgs: 0,
         handler: function (func) {

--- a/static/katex.less
+++ b/static/katex.less
@@ -263,13 +263,8 @@
         left: 0;
     }
 
-    .katex-logo {
-        .a {
-            font-size: 0.75em;
-            margin-left: -0.32em;
-            position: relative;
-            top: -0.2em;
-        }
+    .katex-logo,
+    .latex-logo {
         .t {
             margin-left: -0.23em;
         }
@@ -280,6 +275,23 @@
         }
         .x {
             margin-left: -0.125em;
+        }
+    }
+
+    .katex-logo {
+        .a {
+            font-size: 0.75em;
+            margin-left: -0.32em;
+            position: relative;
+            top: -0.2em;
+        }
+    }
+    .latex-logo {
+        .a {
+            font-size: 0.75em;
+            margin-left: -0.45em;
+            margin-right: 0.15em;
+            vertical-align: 0.25em;
         }
     }
 


### PR DESCRIPTION
Add function that produces the `\LaTeX` symbol. Only thing different from `\KaTeX` symbol is the `A`.

Values tweaked to most closely represent this LaTeX symbol from Wikimedia: ![Wikimedia LaTeX symbol](https://upload.wikimedia.org/wikipedia/commons/9/92/LaTeX_logo.svg)

Screenshot:

![latex symbol](https://cloud.githubusercontent.com/assets/4154884/4431270/5618f6dc-465f-11e4-910c-d5102701bcfc.png)
