### PR TITLE
Added support for \cfrac

### DIFF
--- a/src/ParseNode.js
+++ b/src/ParseNode.js
@@ -1,0 +1,10 @@
+/**
+ * The resulting parse tree nodes of the parse tree.
+ */
+function ParseNode(type, value, mode) {
+    this.type = type;
+    this.value = value;
+    this.mode = mode;
+}
+
+module.exports = ParseNode;

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -4,6 +4,7 @@ var symbols = require("./symbols");
 var utils = require("./utils");
 
 var ParseError = require("./ParseError");
+var ParseNode = require("./ParseNode");
 
 /**
  * This file contains the parser used to parse out a TeX expression from the
@@ -46,15 +47,6 @@ var ParseError = require("./ParseError");
 function Parser(input) {
     // Make a new lexer
     this.lexer = new Lexer(input);
-}
-
-/**
- * The resulting parse tree nodes of the parse tree.
- */
-function ParseNode(type, value, mode) {
-    this.type = type;
-    this.value = value;
-    this.mode = mode;
 }
 
 /**

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -41,6 +41,23 @@ var makeSymbol = function(value, style, mode, color, classes) {
 };
 
 /**
+ * Makes a strut
+ */
+var makeStrut = function() {
+    return new domTree.symbolNode("", 0.85, 0.35);
+};
+
+/**
+ * Inserts kerning where value is specified in ems.
+ * @param value
+ */
+var makeKern = function(value) {
+    var span = new domTree.span(["kern"], [new domTree.symbolNode("\u200b")]);
+    span.style.marginRight = value + "em";
+    return span;
+};
+
+/**
  * Makes a symbol in the italic math font.
  */
 var mathit = function(value, mode, color, classes) {
@@ -267,5 +284,7 @@ module.exports = {
     mathrm: mathrm,
     makeSpan: makeSpan,
     makeFragment: makeFragment,
-    makeVList: makeVList
+    makeVList: makeVList,
+    makeStrut: makeStrut,
+    makeKern: makeKern
 };

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -169,6 +169,14 @@ var groupTypes = {
             group.value, group.mode, options.getColor(), ["mord"]);
     },
 
+    strut: function(group, options, prev) {
+        return buildCommon.makeStrut();
+    },
+
+    kern: function(group, options, prev) {
+        return buildCommon.makeStrut(group.value);
+    },
+
     bin: function(group, options, prev) {
         var className = "mbin";
         // Pull out the most recent element. Do some special handling to find
@@ -471,6 +479,11 @@ var groupTypes = {
         // Rule 15e
         var innerChildren = [makeSpan(["mfrac"], [frac])];
 
+        var nullDelimiter = fontMetrics.metrics.nullDelimiter;
+        if (group.value.continued) {
+            innerChildren.push(buildCommon.makeKern(-nullDelimiter));
+        }
+
         var delimSize;
         if (fstyle.size === Style.DISPLAY.size) {
             delimSize = fontMetrics.metrics.delim1;
@@ -484,6 +497,9 @@ var groupTypes = {
                     group.value.leftDelim, delimSize, true,
                     options.withStyle(fstyle), group.mode)
             );
+        } else {
+            // create a null delimiter
+            innerChildren.unshift(buildCommon.makeKern(nullDelimiter));
         }
         if (group.value.rightDelim != null) {
             innerChildren.push(
@@ -491,6 +507,9 @@ var groupTypes = {
                     group.value.rightDelim, delimSize, true,
                     options.withStyle(fstyle), group.mode)
             );
+        } else {
+            // create a null delimiter
+            innerChildren.push(buildCommon.makeKern(nullDelimiter));
         }
 
         return makeSpan(

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -479,9 +479,9 @@ var groupTypes = {
         // Rule 15e
         var innerChildren = [makeSpan(["mfrac"], [frac])];
 
-        var nullDelimiter = fontMetrics.metrics.nullDelimiter;
+        var nulldelimiterspace = fontMetrics.metrics.nulldelimiterspace;
         if (group.value.continued) {
-            innerChildren.push(buildCommon.makeKern(-nullDelimiter));
+            innerChildren.push(buildCommon.makeKern(-nulldelimiterspace));
         }
 
         var delimSize;
@@ -499,7 +499,7 @@ var groupTypes = {
             );
         } else {
             // create a null delimiter
-            innerChildren.unshift(buildCommon.makeKern(nullDelimiter));
+            innerChildren.unshift(buildCommon.makeKern(nulldelimiterspace));
         }
         if (group.value.rightDelim != null) {
             innerChildren.push(
@@ -509,7 +509,7 @@ var groupTypes = {
             );
         } else {
             // create a null delimiter
-            innerChildren.push(buildCommon.makeKern(nullDelimiter));
+            innerChildren.push(buildCommon.makeKern(nulldelimiterspace));
         }
 
         return makeSpan(

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -369,6 +369,7 @@ var groupTypes = {
         // Figure out what style this fraction should be in based on the
         // function used
         var fstyle = options.style;
+
         if (group.value.size === "display") {
             fstyle = Style.DISPLAY;
         } else if (group.value.size === "text") {

--- a/src/fontMetrics.js
+++ b/src/fontMetrics.js
@@ -109,7 +109,7 @@ var metrics = {
     },
 
     // \nulldelimiterspace=1.2pt, pg. 344 TeXbook
-    nullDelimiter: 1.2 / ptPerEm
+    nulldelimiterspace: 1.2 / ptPerEm
 };
 
 // This map contains a mapping from font name and character code to character

--- a/src/fontMetrics.js
+++ b/src/fontMetrics.js
@@ -106,7 +106,10 @@ var metrics = {
             return sigma21ScriptScript;
         }
         throw new Error("Unexpected style size: " + style.size);
-    }
+    },
+
+    // \nulldelimiterspace=1.2pt, pg. 344 TeXbook
+    nullDelimiter: 1.2 / ptPerEm
 };
 
 // This map contains a mapping from font name and character code to character

--- a/src/functions.js
+++ b/src/functions.js
@@ -320,7 +320,7 @@ var duplicatedFunctions = [
     // Fractions
     {
         funcs: [
-            "\\dfrac", "\\frac", "\\tfrac",
+            "\\dfrac", "\\frac", "\\tfrac", "\\cfrac",
             "\\dbinom", "\\binom", "\\tbinom"
         ],
         data: {
@@ -336,6 +336,7 @@ var duplicatedFunctions = [
                     case "\\dfrac":
                     case "\\frac":
                     case "\\tfrac":
+                    case "\\cfrac":
                         hasBarLine = true;
                         break;
                     case "\\dbinom":
@@ -351,6 +352,7 @@ var duplicatedFunctions = [
 
                 switch (func) {
                     case "\\dfrac":
+                    case "\\cfrac":
                     case "\\dbinom":
                         size = "display";
                         break;

--- a/src/functions.js
+++ b/src/functions.js
@@ -1,5 +1,6 @@
 var utils = require("./utils");
 var ParseError = require("./ParseError");
+var ParseNode = require("./ParseNode");
 
 // This file contains a list of functions that we parse. The functions map
 // contains the following data:
@@ -362,8 +363,17 @@ var duplicatedFunctions = [
                         break;
                 }
 
+                if (func === "\\cfrac") {
+                    if (numer.type === "ordgroup") {
+                        numer.value.push(new ParseNode("strut", null, "math"));
+                    } else {
+                        throw new Error("expect an 'ordgroup' for the numerator");
+                    }
+                }
+
                 return {
                     type: "genfrac",
+                    continued: func === "\\cfrac",
                     numer: numer,
                     denom: denom,
                     hasBarLine: hasBarLine,

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -440,6 +440,7 @@ describe("A frac parser", function() {
     var expression = "\\frac{x}{y}";
     var dfracExpression = "\\dfrac{x}{y}";
     var tfracExpression = "\\tfrac{x}{y}";
+    var cfracExpression = "\\cfrac{x}{y}";
 
     it("should not fail", function() {
         expect(expression).toParse();
@@ -471,6 +472,12 @@ describe("A frac parser", function() {
         expect(tfracParse.type).toMatch("frac");
         expect(tfracParse.value.numer).toBeDefined();
         expect(tfracParse.value.denom).toBeDefined();
+
+        var cfracParse = parseTree(cfracExpression)[0];
+
+        expect(cfracParse.type).toMatch("frac");
+        expect(cfracParse.value.numer).toBeDefined();
+        expect(cfracParse.value.denom).toBeDefined();
     });
 });
 


### PR DESCRIPTION
This addresses issue https://github.com/Khan/KaTeX/issues/85.

It needs a huxley test.  I've attached some screenshots of `\cfrac` vs `\dfrac`.  I also did some tests with LaTeX to make sure that I was getting the proper spacing.

@xymostech If you happy with the rendering do you want me to try and update the huxley tests?

cfrac:
![screen shot 2014-09-28 at 5 59 24 pm](https://cloud.githubusercontent.com/assets/1044413/4436201/08708de2-476c-11e4-8b7d-98f39bc0d25e.png)

dfrac:
![screen shot 2014-09-28 at 5 59 52 pm](https://cloud.githubusercontent.com/assets/1044413/4436203/13bcb1da-476c-11e4-9574-23fbc61dfa4f.png)

cfrac vs dfrac in LaTeX
![screen shot 2014-09-28 at 6 05 56 pm](https://cloud.githubusercontent.com/assets/1044413/4436211/6acb7ae2-476c-11e4-9a94-376253b38899.png)
