### PR TITLE
Add support for basic comparison operands

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -441,6 +441,11 @@ var symbols = {
             group: "rel",
             replace: "\u2245"
         },
+        "\\gt": {
+            font: "main",
+            group: "rel",
+            replace: ">"
+        },
         "\\ge": {
             font: "main",
             group: "rel",
@@ -506,6 +511,11 @@ var symbols = {
             group: "rel",
             replace: "\u2190"
         },
+        "\\lt": {
+            font: "main",
+            group: "rel",
+            replace: "<"
+        },
         "\\le": {
             font: "main",
             group: "rel",
@@ -515,6 +525,11 @@ var symbols = {
             font: "main",
             group: "rel",
             replace: "\u2264"
+        },
+        "\\eq": {
+            font: "main",
+            group: "rel",
+            replace: "="
         },
         "\\ne": {
             font: "main",


### PR DESCRIPTION
It is a common practice to use `\lt`, `\gt`, `\eq` instead of `<`, `>`
and `=` in formulas. This also helps in achieving MathJax compatibility.