### PR TITLE
Added relation mathematical symbols

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -366,6 +366,61 @@ var symbols = {
             group: "bin",
             replace: "\u2228"
         },
+        "\\mp": {
+            font: "main",
+            group: "bin",
+            replace: "\u2213"
+        },
+        "\\ominus": {
+            font: "main",
+            group: "textord",
+            replace: "\u2296"
+        },
+        "\\uplus": {
+            font: "main",
+            group: "textord",
+            replace: "\u228e"
+        },
+        "\\sqcap": {
+            font: "main",
+            group: "bin",
+            replace: "\u2293"
+        },
+        "\\ast": {
+            font: "main",
+            group: "bin",
+            replace: "\u2217"
+        },
+        "\\sqcup": {
+            font: "main",
+            group: "bin",
+            replace: "\u2294"
+        },
+        "\\bigcirc": {
+            font: "main",
+            group: "bin",
+            replace: "\u25cb"
+        },
+        "\\bullet": {
+            font: "main",
+            group: "textord",
+            replace: "\u2219"
+        },
+        "\\ddagger": {
+            font: "main",
+            group: "textord",
+            replace: "\u2021"
+        },
+        "\\wr": {
+            font: "main",
+            group: "bin",
+            replace: "\u2240"
+        },
+        "\\amalg": {
+            font: "main",
+            group: "bin",
+            replace: "\u2a3f"
+        },
         "\\surd": {
             font: "main",
             group: "textord",

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -877,6 +877,51 @@ var symbols = {
             group: "textord",
             replace: "\u22a1"
         },
+        "\\hbar": {
+            font: "main",
+            group: "textord",
+            replace: "\u210f"
+        },
+        "\\imath": {
+            font: "main",
+            group: "mathord",
+            replace: "\u0131"
+        },
+        "\\jmath": {
+            font: "main",
+            group: "mathord",
+            replace: "\u0237"
+        },
+        "\\ell": {
+            font: "main",
+            group: "textord",
+            replace: "\u2113"
+        },
+        "\\Re": {
+            font: "main",
+            group: "textord",
+            replace: "\u211c"
+        },
+        "\\Im": {
+            font: "main",
+            group: "textord",
+            replace: "\u2111"
+        },
+        "\\wp": {
+            font: "main",
+            group: "textord",
+            replace: "\u2118"
+        },
+        "\\nabla": {
+            font: "main",
+            group: "textord",
+            replace: "\u2207"
+        },
+        "\\Box": {
+            font: "main",
+            group: "textord",
+            replace: "\u25a1"
+        },
         "\\bigtriangleup": {
             font: "main",
             group: "textord",
@@ -912,6 +957,7 @@ var symbols = {
             group: "textord",
             replace: "\u25b9"
         },
+
         "\\{": {
             font: "main",
             group: "open",

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -546,6 +546,131 @@ var symbols = {
             group: "rel",
             replace: "\u2270"
         },
+        "\\ll": {
+            font: "main",
+            group: "rel",
+            replace: "\u226a"
+        },
+        "\\gg": {
+            font: "main",
+            group: "rel",
+            replace: "\u226b"
+        },
+        "\\sqsubset": {
+            font: "main",
+            group: "rel",
+            replace: "\u228f"
+        },
+        "\\sqsubseteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2291"
+        },
+        "\\sqsupset": {
+            font: "main",
+            group: "rel",
+            replace: "\u2290"
+        },
+        "\\sqsupseteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2292"
+        },
+        "\\prec": {
+            font: "main",
+            group: "rel",
+            replace: "\u227a"
+        },
+        "\\preceq": {
+            font: "main",
+            group: "rel",
+            replace: "\u227c"
+        },
+        "\\succ": {
+            font: "main",
+            group: "rel",
+            replace: "\u227b"
+        },
+        "\\succeq": {
+            font: "main",
+            group: "rel",
+            replace: "\u227d"
+        },
+        "\\doteq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2250"
+        },
+        "\\equiv": {
+            font: "main",
+            group: "rel",
+            replace: "\u2261"
+        },
+        "\\simeq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2243"
+        },
+        "\\sim": {
+            font: "main",
+            group: "rel",
+            replace: "\u223c"
+        },
+        "\\parallel": {
+            font: "main",
+            group: "rel",
+            replace: "\u2225"
+        },
+        "\\nparallel": {
+            font: "main",
+            group: "rel",
+            replace: "\u2226"
+        },
+        "\\perp": {
+            font: "main",
+            group: "rel",
+            replace: "\u22a5"
+        },
+        "\\asymp": {
+            font: "main",
+            group: "rel",
+            replace: "\u224d"
+        },
+        "\\vdash": {
+            font: "main",
+            group: "rel",
+            replace: "\u22a2"
+        },
+        "\\smile": {
+            font: "main",
+            group: "rel",
+            replace: "\u2323"
+        },
+        "\\frown": {
+            font: "main",
+            group: "rel",
+            replace: "\u2322"
+        },
+        "\\bowtie": {
+            font: "main",
+            group: "rel",
+            replace: "\u22c8"
+        },
+        "\\dashv": {
+            font: "main",
+            group: "rel",
+            replace: "\u22a3"
+        },
+        "\\ni": {
+            font: "main",
+            group: "rel",
+            replace: "\u220b"
+        },
+        "\\mid": {
+            font: "main",
+            group: "rel",
+            replace: "\u2223"
+        },
         "\\!": {
             font: "main",
             group: "spacing"

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -272,6 +272,11 @@ var symbols = {
             group: "mathord",
             replace: "\u03d1"
         },
+        "\\varkappa": {
+            font: "main",
+            group: "mathord",
+            replace: "\u03f0"
+        },
         "\\varpi": {
             font: "main",
             group: "mathord",

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -726,6 +726,56 @@ var symbols = {
             group: "rel",
             replace: "\u2223"
         },
+        "\\exists": {
+            font: "main",
+            group: "textord",
+            replace: "\u2203"
+        },
+        "\\nexists": {
+            font: "main",
+            group: "textord",
+            replace: "\u2204"
+        },
+        "\\forall": {
+            font: "main",
+            group: "textord",
+            replace: "\u2200"
+        },
+        "\\mapsto": {
+            font: "main",
+            group: "rel",
+            replace: "\u21a6"
+        },
+        "\\implies": {
+            font: "main",
+            group: "rel",
+            replace: "\u21d2"
+        },
+        "\\Rightarrow": {
+            font: "main",
+            group: "rel",
+            replace: "\u21d2"
+        },
+        "\\leftrightarrow": {
+            font: "main",
+            group: "rel",
+            replace: "\u2194"
+        },
+        "\\iff": {
+            font: "main",
+            group: "rel",
+            replace: "\u27fa"
+        },
+        "\\notin": {
+            font: "main",
+            group: "rel",
+            replace: "\u2209"
+        },
+        "\\Leftrightarrow": {
+            font: "main",
+            group: "rel",
+            replace: "\u21d4"
+        },
         "\\!": {
             font: "main",
             group: "spacing"

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -766,11 +766,6 @@ var symbols = {
             group: "rel",
             replace: "\u27fa"
         },
-        "\\notin": {
-            font: "main",
-            group: "rel",
-            replace: "\u2209"
-        },
         "\\Leftrightarrow": {
             font: "main",
             group: "rel",


### PR DESCRIPTION
Added the following relation, binary operation, and set/logic symbols, and other symbolds listed in the link below that were not already present.

http://en.wikibooks.org/wiki/LaTeX/Mathematics#List_of_Mathematical_Symbols

Added relation symbols:

`\ll\gg\sqsubset\sqsubseteq\sqsupset\sqsupseteq\prec\preceq\succ\succeq\doteq\equiv\simeq\sim\parallel\nparallel\perp\asymp\vdash\smile\frown\bowtie\dashv\ni\mid`

Added binary operation symbols:

`\mp\ominus\uplus\sqcap\ast\sqcup\bigcirc\bullet\ddagger\wr\amalg`

Added set/logic notation symbols:

`\exists\nexists\forall\mapsto\implies\Rightarrow\leftrightarrow\iff\Leftrightarrow`

Added Greek letters:

`\varkappa`

Other symbols:

`\hbar\imath\jmath\ell\Re\Im\wp\nabla`

I tried to add `\eth\aleph\beth\gimel` with the following code, but they did not display how I expected them to, so I'm leaving them out for now.

	"\\eth": {
		font: "main",
		group: "textord",
		replace: "\u00f0"
	},
	"\\aleph": {
		font: "ams",
		group: "textord",
		replace: "\u05d0"
	},
	"\\beth": {
		font: "main",
		group: "textord",
		replace: "\u05d1"
	},
	"\\gimel": {
		font: "main",
		group: "textord",
		replace: "\u05d2"
	},

I don't completely understand when to use the `bin`, `textord` or `mathord` groups, could somebody explain that?