### PR TITLE
 Added 14 Symbols

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -326,6 +326,11 @@ var symbols = {
             group: "bin",
             replace: "\u00b1"
         },
+	"\\mp": {
+	    font: "main",
+	    group: "bin",
+	    replace: "\u2213"
+	},
         "\\times": {
             font: "main",
             group: "bin",
@@ -341,6 +346,21 @@ var symbols = {
             group: "bin",
             replace: "\u222a"
         },
+	"\\uplus": {
+	    font: "main",
+	    group: "bin",
+	    replace: "\u228e"
+	},
+	"\\sqcap": {
+	    font: "main",
+	    group: "bin",
+	    replace: "\u2293"
+	},
+	"\\sqcup": {
+	    font: "main",
+	    group: "bin",
+	    replace: "\u2294"
+	},
         "\\setminus": {
             font: "main",
             group: "bin",
@@ -366,11 +386,31 @@ var symbols = {
             group: "bin",
             replace: "\u2228"
         },
+	"\\bigcirc": {
+	    font: "main",
+	    group: "bin",
+	    replace: "\u25ef"
+	},
+	"\\amalg": {
+	    font: "main",
+	    group: "bin",
+	    replace: "\u2a3f"
+	},
         "\\surd": {
             font: "main",
             group: "textord",
             replace: "\u221a"
         },
+	"\\ddagger": {
+	    font: "main",
+	    group: "textord",
+	    replace: "\u2021"
+	},
+	"\\ominus": {
+	    font: "main",
+	    group: "textord",
+	    replace: "\u2297"
+	},
         "(": {
             font: "main",
             group: "open"
@@ -546,6 +586,36 @@ var symbols = {
             group: "rel",
             replace: "\u2270"
         },
+	"\\forall": {
+	    font: "main",
+	    group: "rel",
+	    replace: "\u2200"
+	},
+	"\\exists": {
+	    font: "main",
+	    group: "rel",
+	    replace: "\u2203"
+	},
+	"\\nexists": {
+	    font: "main",
+	    group: "rel",
+	    replace: "\u2204"
+	},
+	"\\implies": {
+	    font: "main",
+	    group: "rel",
+	    replace: "\u21d2"
+	},
+	"\\iff": {
+	    font: "main",
+	    group: "rel",
+	    replace: "\u21d4"
+	},
+	"\\ni": {
+	    font: "main",
+	    group: "rel",
+	    replace: "\u2204"
+	},
         "\\!": {
             font: "main",
             group: "spacing"

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -409,7 +409,7 @@ var symbols = {
 	"\\ominus": {
 	    font: "main",
 	    group: "textord",
-	    replace: "\u2297"
+	    replace: "\u2296"
 	},
         "(": {
             font: "main",
@@ -614,7 +614,7 @@ var symbols = {
 	"\\ni": {
 	    font: "main",
 	    group: "rel",
-	    replace: "\u2204"
+	    replace: "\u220d"
 	},
         "\\!": {
             font: "main",


### PR DESCRIPTION
Hello Emily and Ben,

Apologies for not emailing you back Emily. After reading the contribution file, we decided to add a few symbols. If the pull request is approved we get a bonus 5 lab marks. It's not worth a lot but anything helps. Hopefully we helped KaTeX a little bit.

The symbols added are: ⊎ ⊓ ⊔ ⊖ ◯ ‡ ⨿ ∃ ∄ ∀ ⇒ ⇔ ∍