### PR TITLE
Add double arrows and preference symbols for economics

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -436,6 +436,11 @@ var symbols = {
             group: "rel",
             replace: "\u2248"
         },
+        "\\sim": {
+            font: "main",
+            group: "rel",
+            replace: "\u223c"
+        },
         "\\cong": {
             font: "main",
             group: "rel",
@@ -450,6 +455,16 @@ var symbols = {
             font: "main",
             group: "rel",
             replace: "\u2265"
+        },
+        "\\succsim": {
+            font: "main",
+            group: "rel",
+            replace: "\u227f"
+        },
+        "\\succ": {
+            font: "main",
+            group: "rel",
+            replace: "\u227b"
         },
         "\\gets": {
             font: "main",
@@ -521,6 +536,16 @@ var symbols = {
             group: "rel",
             replace: "\u2264"
         },
+        "\\prec": {
+            font: "main",
+            group: "rel",
+            replace: "\u227a"
+        },
+        "\\precsim": {
+            font: "main",
+            group: "rel",
+            replace: "\u227e"
+        },
         "\\ne": {
             font: "main",
             group: "rel",
@@ -530,6 +555,11 @@ var symbols = {
             font: "main",
             group: "rel",
             replace: "\u2260"
+        },
+        "\\nsim": {
+            font: "main",
+            group: "rel",
+            replace: "\u2241"
         },
         "\\rightarrow": {
             font: "main",

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -506,6 +506,11 @@ var symbols = {
             group: "rel",
             replace: "\u2190"
         },
+        "\\Leftarrow": {
+            font: "main",
+            group: "rel",
+            replace: "\u21D0"
+        },
         "\\le": {
             font: "main",
             group: "rel",
@@ -530,6 +535,11 @@ var symbols = {
             font: "main",
             group: "rel",
             replace: "\u2192"
+        },
+        "\\Rightarrow": {
+            font: "main",
+            group: "rel",
+            replace: "\u21D2"
         },
         "\\to": {
             font: "main",

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -461,6 +461,11 @@ var symbols = {
             group: "rel",
             replace: "\u227b"
         },
+        "\\succeq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2ab0"
+        },
         "\\gets": {
             font: "main",
             group: "rel",
@@ -535,6 +540,11 @@ var symbols = {
             font: "main",
             group: "rel",
             replace: "\u227a"
+        },
+        "\\preceq": {
+            font: "main",
+            group: "rel",
+            replace: "\u2aaf"
         },
         "\\ne": {
             font: "main",

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -456,11 +456,6 @@ var symbols = {
             group: "rel",
             replace: "\u2265"
         },
-        "\\succsim": {
-            font: "main",
-            group: "rel",
-            replace: "\u227f"
-        },
         "\\succ": {
             font: "main",
             group: "rel",
@@ -540,11 +535,6 @@ var symbols = {
             font: "main",
             group: "rel",
             replace: "\u227a"
-        },
-        "\\precsim": {
-            font: "main",
-            group: "rel",
-            replace: "\u227e"
         },
         "\\ne": {
             font: "main",


### PR DESCRIPTION
Added symbols \LeftArrow and \Rightarrow (double arrows), as well as \prec, \sim, \nsim, and \succ (preference symbols for economics) to symbols.js.

Tested in browser to ensure font compatibility (dropped \precsim and \succsim, which I had originally included, because they raised font errors). Also ran make test. 

Please let me know if you would like me to change something! I anticipate the possibility of needing additional symbols in the future.

Thanks for creating this amazing resource!

Chris

UPDATE: found some equivalent symbols for weak preferences that don't cause font problems; added those in.