### PR TITLE
Adds `onlyMathML` setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ You can provide an object of options as the last argument to `katex.render` and 
 
 - `displayMode`: `boolean`. If `true` the math will be rendered in display mode, which will put the math in display style (so `\int` and `\sum` are large, for example), and will center the math on the page on its own line. If `false` the math will be rendered in inline mode. (default: `false`)
 
+
 For example:
 
 ```js
 katex.render("c = \\pm\\sqrt{a^2 + b^2}", element, { displayMode: true });
 ```
+
+- `onlyMathML`: `boolean`. If `true` the resulting markup will only contain MathML. (default: `false`)
 
 ## Contributing
 

--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 // Simple CLI for KaTeX.
 // Reads TeX from stdin, outputs HTML to stdout.
+//
+minimist = require("minimist");
+Settings = require("./src/Settings");
+var args = minimist(process.argv.slice(2));
+
+var settings = new Settings({
+  displayMode: args.d || args.display,
+});
 
 var katex = require("./");
 var input = "";
@@ -10,6 +18,6 @@ process.stdin.on("data", function(chunk) {
 });
 
 process.stdin.on("end", function() {
-  var output = katex.renderToString(input);
+  var output = katex.renderToString(input, settings);
   console.log(output);
 });

--- a/cli.js
+++ b/cli.js
@@ -8,6 +8,7 @@ var args = minimist(process.argv.slice(2));
 
 var settings = new Settings({
   displayMode: args.d || args.display,
+  onlyMathML: args.m || args.mathml
 });
 
 var katex = require("./");

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "bin": "cli.js",
   "scripts": {
     "test": "make lint test"
+  },
+  "dependencies": {
+    "minimist": "^1.1.1"
   }
 }

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -21,6 +21,7 @@ function Settings(options) {
     // allow null options
     options = options || {};
     this.displayMode = get(options.displayMode, false);
+    this.onlyMathML = get(options.onlyMathML, false);
 }
 
 module.exports = Settings;

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -435,6 +435,10 @@ var buildMathML = function(tree, texExpression, settings) {
 
     var math = new mathMLTree.MathNode("math", [semantics]);
 
+    if (typeof settings === "object" && settings.displayMode && settings.onlyMathML) {
+        math.setAttribute("display", "block");
+    }
+
     // You can't style <math> nodes, so we wrap the node in a span.
     return makeSpan(["katex-mathml"], [math]);
 };

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -9,6 +9,12 @@ var buildTree = function(tree, expression, settings) {
     // `buildHTML` sometimes messes with the parse tree (like turning bins ->
     // ords), so we build the MathML version first.
     var mathMLNode = buildMathML(tree, expression, settings);
+    
+    if (settings.onlyMathML) {
+        // mathMLNode is wrapped in a <span>
+        return mathMLNode.children[0];
+    }
+
     var htmlNode = buildHTML(tree, settings);
 
     var katexNode = makeSpan(["katex"], [


### PR DESCRIPTION
When set the output markup will be MathML only. This is useful in order to use KaTeX as a TeX to MathML converter.