### PR TITLE
Partly fixes #48: added optional arguments to sqrt

### DIFF
--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -812,7 +812,26 @@ var groupTypes = {
             ], "firstBaseline", null, options);
         }
 
-        return makeSpan(["sqrt", "mord"], [delim, body]);
+        if(!group.value.optional) {
+            return makeSpan(["sqrt", "mord"], [delim, body]);            
+        } else {
+            var optionInner = buildGroup(group.value.optional,
+                options.withStyle(options.style.sup()));
+            var optionInnerSpan;
+            optionInnerSpan = makeSpan(
+                [options.style.reset(), options.style.sup().cls()], [optionInner]);
+
+            var toShift; //determines vertical shift
+            if (options.style === Style.DISPLAY) {
+                toShift = fontMetrics.metrics.sup1;
+            } else if (options.style.cramped) {            
+                toShift = fontMetrics.metrics.sup3;
+            } else {
+                toShift = fontMetrics.metrics.sup2;
+            }
+            var rootpower = buildCommon.makeVList([{type: "elem", elem: optionInnerSpan}],"shift", -toShift, options);
+            return makeSpan(["sqrt", "mord", "optional"], [rootpower, delim, body]); 
+        }
     },
 
     sizing: function(group, options, prev) {

--- a/src/functions.js
+++ b/src/functions.js
@@ -73,9 +73,14 @@ var functions = {
         numOptionalArgs: 1,
         handler: function(func, optional, body, positions) {
             if (optional != null) {
-                throw new ParseError(
-                    "Optional arguments to \\sqrt aren't supported yet",
-                    this.lexer, positions[1] - 1);
+                return {
+                    type: "sqrt",
+                    body: body,
+                    optional: optional
+                };
+                // throw new ParseError(
+                //     "Optional arguments to \\sqrt aren't supported yet",
+                //     this.lexer, positions[1] - 1);
             }
 
             return {


### PR DESCRIPTION
I changed functions.js and buildHTML.js files to support optional arguments to the sqrt function. This partly fixes #48 .

The buildMathML.js file still needs to be changed.