### PR TITLE
Add \# and \& to AMS misc symbols

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -152,6 +152,16 @@ var symbols = {
         },
 
         // Misc Symbols
+        "\\#": {
+          font: "main",
+          group: "textord",
+          replace: "\u0023"
+        },
+        "\\&": {
+          font: "main",
+          group: "textord",
+          replace: "\u0026"
+        },
         "\\aleph": {
             font: "main",
             group: "textord",


### PR DESCRIPTION
Those symbols are listed in
ftp://ftp.ams.org/pub/tex/doc/amsmath/short-math-guide.pdf, section 3.6

I don't know if I have done this correctly, or if adding support for these symbols conflicts with something else. The tests run fine though. Please let me know!