### PR TITLE
buildHTML's buildExpression is destructive, changing the tree object.

### DIFF
--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -1157,6 +1157,10 @@ var buildGroup = function(group, options, prev) {
  * nodes.
  */
 var buildHTML = function(tree, settings) {
+    // buildExpression is destructive, so we need to make a clone
+    // of the incoming tree so that it isn't accidentally changed
+    tree = JSON.parse(JSON.stringify(tree));
+
     var startStyle = Style.TEXT;
     if (settings.displayMode) {
         startStyle = Style.DISPLAY;


### PR DESCRIPTION
This clones the object first before manipulating it, ensuring that the tree object will remain the same (right now if buildHTML was run before buildMathML, buildMathML would have weird failures).

I was able to reproduce this by running `\vec{A}^2` through KaTeX. Without this change `tree` becomes:

```json
[
    {
        "type": "supsub",
        "value": {
            "base": {
                "type": "ordgroup",
                "value": [
                    {
                        "type": "mathord",
                        "value": "A",
                        "mode": "math"
                    }
                ],
                "mode": "math"
            },
            "sup": {
                "type": "textord",
                "value": "2",
                "mode": "math"
            }
        },
        "mode": "math"
    }
]
```

With this change it's left as the correct:

```json
[
    {
        "type": "supsub",
        "value": {
            "base": {
                "type": "accent",
                "value": {
                    "type": "accent",
                    "accent": "\\vec",
                    "base": {
                        "type": "ordgroup",
                        "value": [
                            {
                                "type": "mathord",
                                "value": "A",
                                "mode": "math"
                            }
                        ],
                        "mode": "math"
                    }
                },
                "mode": "math"
            },
            "sup": {
                "type": "textord",
                "value": "2",
                "mode": "math"
            }
        },
        "mode": "math"
    }
]
```