### PR TITLE
Expose a new .__parse() method for generating a parse tree from a math expression

### DIFF
--- a/katex.js
+++ b/katex.js
@@ -52,8 +52,22 @@ var renderToString = function(expression, options) {
     return buildTree(tree, expression, settings).toMarkup();
 };
 
+/**
+ * Parse an expression and return the parse tree.
+ */
+var generateParseTree = function(expression, options) {
+    var settings = new Settings(options);
+    return parseTree(expression, settings);
+};
+
 module.exports = {
     render: render,
     renderToString: renderToString,
+    /**
+     * NOTE: This method is not currently recommended for public use.
+     * The internal tree representation is unstable and is very likely
+     * to change. Use at your own risk.
+     */
+    __parse: generateParseTree,
     ParseError: ParseError
 };

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1116,6 +1116,31 @@ describe("A markup generator", function() {
     });
 });
 
+describe("A parse tree generator", function() {
+    it("generates a tree", function() {
+        var tree = katex.__parse("\\sigma^2");
+        expect(JSON.stringify(tree)).toEqual(JSON.stringify([
+            {
+                "type": "supsub",
+                "value": {
+                    "base": {
+                        "type": "mathord",
+                        "value": "\\sigma",
+                        "mode": "math"
+                    },
+                    "sup": {
+                        "type": "textord",
+                        "value": "2",
+                        "mode": "math"
+                    },
+                    "sub": undefined
+                },
+                "mode": "math"
+            }
+        ]));
+    });
+});
+
 describe("An accent parser", function() {
     it("should not fail", function() {
         expect("\\vec{x}").toParse();


### PR DESCRIPTION
Explicitly marked with tons of warnings, both in name and in comments. To be used for some internal projects, for the time being. Added a simple test, just as a sanity check.