### PR TITLE
Implement \mathbb

### DIFF
--- a/server.js
+++ b/server.js
@@ -65,6 +65,7 @@ app.use(express["static"](path.join(__dirname, "static")));
 app.use(express["static"](path.join(__dirname, "build")));
 app.use("/test", express["static"](path.join(__dirname, "test")));
 app.use("/contrib", express["static"](path.join(__dirname, "contrib")));
+app.use("/tools", express["static"](path.join(__dirname, "tools")));
 
 app.use(function(err, req, res, next) {
     console.error(err.stack);

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -308,6 +308,28 @@ var spacingFunctions = {
     }
 };
 
+var specialFonts = {
+    "\\mathbb": {
+        font: "AMS-Regular",
+        support: "ABCDEFGHIJKLMNOPQRSTUVWXYZk",
+        unicode: "𝔸𝔹ℂ𝔻𝔼𝔽𝔾ℍ𝕀𝕁𝕂𝕃𝕄ℕ𝕆ℙℚℝ𝕊𝕋𝕌𝕍𝕎𝕏𝕐ℤ𝕜",
+        classes: ["amsrm", "mathbb"]
+    },
+    "\\mathcal": {
+        font: "Caligraphic-Regular",
+        support: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        unicode: "𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵",
+        classes: ["mathcal"]
+    },
+    "\\mathscr": {
+        font: "Script-Regular",
+        support: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        unicode: "𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵",
+        classes: ["mathscr"]
+    }
+};
+specialFonts["\\Bbb"] = specialFonts["\\mathbb"];
+
 module.exports = {
     makeSymbol: makeSymbol,
     mathit: mathit,
@@ -316,5 +338,6 @@ module.exports = {
     makeFragment: makeFragment,
     makeVList: makeVList,
     sizingMultiplier: sizingMultiplier,
-    spacingFunctions: spacingFunctions
+    spacingFunctions: spacingFunctions,
+    specialFonts: specialFonts
 };

--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -1210,6 +1210,30 @@ var groupTypes = {
         // \phantom isn't supposed to affect the elements it contains.
         // See "color" for more details.
         return new buildCommon.makeFragment(elements);
+    },
+
+    specialfont: function(group, options, prev) {
+        var body = group.value.body;
+        var chars;
+        if (body.type === "ordgroup") {
+            chars = body.value.slice();
+        } else {
+            chars = [body];
+        }
+        var spec = buildCommon.specialFonts[group.value.font];
+        for (var i = 0; i < chars.length; ++i) {
+            var chr = chars[i];
+            if (chr.type === "mathord" && chr.value.length === 1 &&
+                spec.support.indexOf(chr.value) !== -1) {
+                chars[i] = buildCommon.makeSymbol(
+                    chr.value, spec.font, "math",
+                    options.getColor(), spec.classes);
+            } else {
+                chars[i] = buildGroup(chr, options, prev);
+            }
+            prev = chr; //(gagern) Is this correct?
+        }
+        return new buildCommon.makeFragment(chars);
     }
 };
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -494,6 +494,24 @@ var duplicatedFunctions = [
         }
     },
 
+    // Special fonts
+    {
+        funcs: [
+            "\\mathbb", "\\Bbb",
+            // these require additional metrics: "\\mathcal", "\\mathscr"
+        ],
+        data: {
+            numArgs: 1,
+            handler: function(func, body) {
+                return {
+                    type: "specialfont",
+                    font: func,
+                    body: body
+                };
+            }
+        }
+    },
+
     // Infix generalized fractions
     {
         funcs: ["\\over", "\\choose"],

--- a/tools/fontView.html
+++ b/tools/fontView.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+ Display all characters of a font.  First extract font data to *ttx files
+ using the TTX tool from https://github.com/behdad/fonttools/.
+ Run "ttx -t cmap static/fonts/*.ttf" to extract that.
+ Then run "node server.js" and open "http://localhost:7936/tools/fontView.html".
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script type="text/javascript" src="fontView.js"></script>
+  </head>
+  <body>
+    <div id="select">
+      <ul>
+        <li><a href="fontView.html?f=KaTeX_AMS-Regular">AMS</a></li>
+        <li><a href="fontView.html?f=KaTeX_Caligraphic-Regular">Caligraphic</a></li>
+        <li><a href="fontView.html?f=KaTeX_Fraktur-Regular">Fraktur</a></li>
+        <li><a href="fontView.html?f=KaTeX_Main-Regular">Main</a></li>
+        <li><a href="fontView.html?f=KaTeX_Math-Regular">Math</a></li>
+        <li><a href="fontView.html?f=KaTeX_SansSerif-Regular">SansSerif</a></li>
+        <li><a href="fontView.html?f=KaTeX_Script-Regular">Script</a></li>
+        <li><a href="fontView.html?f=KaTeX_Size1-Regular">Size1</a></li>
+        <li><a href="fontView.html?f=KaTeX_Size2-Regular">Size2</a></li>
+        <li><a href="fontView.html?f=KaTeX_Size3-Regular">Size3</a></li>
+        <li><a href="fontView.html?f=KaTeX_Size4-Regular">Size4</a></li>
+        <li><a href="fontView.html?f=KaTeX_Typewriter-Regular">Typewriter</a></li>
+      </ul>
+    </div>
+    <div id="table"></div>
+  </body>
+</html>

--- a/tools/fontView.js
+++ b/tools/fontView.js
@@ -1,0 +1,73 @@
+"use strict";
+
+function fontView() {
+    var match = /(?:^\?|&)f=([^&]*)/.exec(window.location.search);
+    if (!match) return;
+    var font = match[1];
+    var style = "@font-face {\n" +
+        "  font-family: '" + font + "';\n" +
+        "  src: url('/fonts/" + font + ".eot');\n  src:" +
+        " url('/fonts/" + font + ".eot#iefix')" +
+        " format('embedded-opentype')," +
+        " url('/fonts/" + font + ".woff2')" +
+        " format('woff2')," +
+        " url('/fonts/" + font + ".woff')" +
+        " format('woff')," +
+        " url('/fonts/" + font + ".ttf')" +
+        " format('ttf');\n" +
+        "  font-weight: normal;\n" +
+        "  font-style: normal;\n" +
+        "}\n\n" +
+        ".curfont {\n" +
+        "  font-family: '" + font + "';\n" +
+        "  font-weight: normal;\n" +
+        "  font-style: normal;\n" +
+        "}\n";
+    var styleElt = document.createElement("style");
+    styleElt.setAttribute("type", "text/css");
+    styleElt.textContent = style;
+    document.head.appendChild(styleElt);
+
+    var req = new XMLHttpRequest();
+    req.open("GET", "/fonts/" + font + ".ttx", true);
+    req.overrideMimeType("application/xml");
+    req.onload = fontData;
+    req.send();
+}
+
+function td(content, className) {
+    var elt = document.createElement("td");
+    elt.textContent = content;
+    elt.className = className;
+    return elt;
+}
+
+function fontData() {
+    var resp = this.responseXML;
+    console.log(resp);
+    var maps = resp.getElementsByTagName("cmap_format_4");
+    var map = null;
+    for (var mapi = 0; mapi < maps.length; ++mapi) {
+        var map = maps[mapi];
+        if (map.getAttribute("platformID") === "3" &&
+            map.getAttribute("platEncID") === "1") {
+            break;
+        }
+    }
+    var table = document.createElement("table");
+    for (var n = map.firstChild; n; n = n.nextSibling) {
+        if (n.nodeType !== 1) continue;
+        var code = parseInt(n.getAttribute("code").substr(2), 16);
+        var str = String.fromCharCode(code);
+        var name = n.getAttribute("name");
+        var tr = document.createElement("tr");
+        tr.appendChild(td(code, "code"));
+        tr.appendChild(td(str, "curfont"));
+        tr.appendChild(td(str, "reffont"));
+        tr.appendChild(td(name, "name"));
+        table.appendChild(tr);
+    }
+    document.getElementById("table").appendChild(table);
+}
+
+fontView();


### PR DESCRIPTION
Since blackboard letters (all uppercase and lower case k) are contained in the AMS font, this requires no additional work on the font support side. The mechanism has been designed to support `\mathcal` and `\mathscr` as well, but these need additional font metrics.

Furthermore, there appears to be no distinction between caligraphic and script letters in Unicode, which will affect the MathML rendering. At least on my system, “𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵” looks like a strange mix between caligraphic and script letters, altghough they are all called “script” by Unicode. Some of them are from the BMP while others are not, which might lead to different fonts being used for them.

In https://github.com/Khan/KaTeX/commit/5e127ba6febe0d0850718c7142863a280c42fb1a I've included a little tool which I used to figure out what symbols are in what places in the KaTeX fonts. I'm not sure whether you'd want something like this included in the final merge. There are probably tools to achieve the same, I don't know. I was a bit surprised to find that the blackboard letters are in the normal alphabetic range, not associated with their Unicode codepoints. I wonder whether it would be possible to add a mapping for these Unicode codepoints in addition to the alphabetic range. KaTeX probably won't need that, though.

There is quite a bit of code duplication between `buildHTML` and `buildMathML`. Should I try to move that to `functions`, i.e. perform as much of the common functionality at parse time? Or should I stuff some of that functionality into a function in `buildCommon`, to which the two builders can delegate?

Is it acceptable to have unescaped unicode literals in the sources? I think that in this case, it makes the code a lot more readable (if your editor plays along), and the `ascii_only=true` argument to uglify will cause these literals to be escaped in the minified version (which I assume is what most people will be using).

For some reason, jshint isn't happy with my code. It complains about `Unexpected use of '&'` in the code which detects an UTF-16 surrogate pair. Do you have any idea of why this message is triggered? Should I experiment with alternate formulations, or just suppress the warning?