### PR TITLE
Update development server for new browserify version

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,15 +11,12 @@ app.use(express.logger());
 
 var serveBrowserified = function(file, standaloneName) {
     return function(req, res, next) {
-        var b = browserify();
-        b.add(file);
-
         var options = {};
         if (standaloneName) {
             options.standalone = standaloneName;
         }
-
-        var stream = b.bundle(options);
+        var b = browserify([file], options);
+        var stream = b.bundle();
 
         var body = "";
         stream.on("data", function(s) { body += s; });


### PR DESCRIPTION
Current browserify no longer accepts an options hash to the bundle method.

Seems I broke the dev server in 1603162267d5a3217ff567847581732220ba7151 for #303.