### PR TITLE
Automatically start a development server

### DIFF
--- a/dockers/Screenshotter/README.md
+++ b/dockers/Screenshotter/README.md
@@ -4,12 +4,8 @@
 
 Now you too can generate screenshots from your own computer, and (hopefully)
 have them look mostly the same as the current ones! Make sure you have docker
-installed and running. Also make sure that the development server is running,
-or start it by running
-
-    node server.js
-
-in the top level directory of the source tree. If all you want is (re)create
+installed and running.
+If all you want is (re)create
 all the snapshots for all the browsers, then you can do so by running the
 `screenshotter.sh` script:
 

--- a/server.js
+++ b/server.js
@@ -7,7 +7,9 @@ var less = require("less");
 
 var app = express();
 
-app.use(express.logger());
+if (require.main === module) {
+    app.use(express.logger());
+}
 
 var serveBrowserified = function(file, standaloneName) {
     return function(req, res, next) {
@@ -69,5 +71,9 @@ app.use(function(err, req, res, next) {
     res.send(500, err.stack);
 });
 
-app.listen(7936);
-console.log("Serving on http://0.0.0.0:7936/ ...");
+if (require.main === module) {
+    app.listen(7936);
+    console.log("Serving on http://0.0.0.0:7936/ ...");
+}
+
+module.exports = app;


### PR DESCRIPTION
This avoids one of the few requirements we have left: you no longer have to start a KaTeX development server, the script will do it for you, using a random port number.

To reproduce the old behaviour, explicitely state `--katex-port=7936`.

Note that in contrast to all the find-an-open-port libraries I looked at, this one will open the server and keeping it open, avoiding the small time window where the open port might get re-used by some other process.