### PR TITLE
Allow for the contrib folder to be included

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,6 @@
     "/build",
     "/test",
     "/src",
-    "/contrib",
     "/dockers",
     "/metrics",
     "/static"


### PR DESCRIPTION
If you include the `/contrib` folder in bower, then we can use its files with gulp/grunt easily. In my case I need `auto-render` and I am including it as a separate file and then joining them, but I think it'd be easier for everyone who wants to use it if it was only a dependency than if it is a dependency and a stray file (that we have to include in other ways).