### PR TITLE
Generate fontMetricsData as JavaScript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ PERL=perl
 PYTHON=$(shell python2 --version >/dev/null 2>&1 && echo python2 || echo python)
 
 metrics:
-	cd metrics && $(PERL) ./mapping.pl | $(PYTHON) ./extract_tfms.py | $(PYTHON) ./extract_ttfs.py | $(PYTHON) ./format_json.py > ../src/fontMetricsData.json
+	cd metrics && $(PERL) ./mapping.pl | $(PYTHON) ./extract_tfms.py | $(PYTHON) ./extract_ttfs.py | $(PYTHON) ./format_json.py > ../src/fontMetricsData.js
 
 clean:
 	rm -rf build/*

--- a/metrics/format_json.py
+++ b/metrics/format_json.py
@@ -13,4 +13,4 @@ for font in sorted(data):
       sys.stdout.write(json.dumps(data[font][glyph], sort_keys=True))
       sep = ",\n  "
   sep = "\n},\n"
-sys.stdout.write("\n}}\n");
+sys.stdout.write("\n}};\n");

--- a/metrics/format_json.py
+++ b/metrics/format_json.py
@@ -4,7 +4,7 @@ import sys
 import json
 
 data = json.load(sys.stdin)
-sep = "{\n"
+sep = "module.exports = {\n"
 for font in sorted(data):
   sys.stdout.write(sep + json.dumps(font))
   sep = ": {\n  "

--- a/src/fontMetricsData.js
+++ b/src/fontMetricsData.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
 "AMS-Regular": {
   "65": {"depth": 0.0, "height": 0.68889, "italic": 0.0, "skew": 0.0},
   "66": {"depth": 0.0, "height": 0.68889, "italic": 0.0, "skew": 0.0},

--- a/src/fontMetricsData.js
+++ b/src/fontMetricsData.js
@@ -1748,4 +1748,4 @@ module.exports = {
   "2018": {"depth": 0.0, "height": 0.61111, "italic": 0.0, "skew": 0.0},
   "2019": {"depth": 0.0, "height": 0.61111, "italic": 0.0, "skew": 0.0},
   "8242": {"depth": 0.0, "height": 0.61111, "italic": 0.0, "skew": 0.0}
-}}
+}};


### PR DESCRIPTION
As described in issue #322, webpack needs additional configuration to parse JSON.
This pull request includes changing the generator script and `fontMetricsData` converted to javascript. 

(That was easier than expected 😊 )  