### PR TITLE
Make texcmp work again, including KaTeX logo

### DIFF
--- a/test/screenshotter/ss_data.yaml
+++ b/test/screenshotter/ss_data.yaml
@@ -52,9 +52,7 @@ Exponents: a^{a^a_a}_{a^a_a}
 FractionTest: \dfrac{a}{b}\frac{a}{b}\tfrac{a}{b}\;-\dfrac12\;1\tfrac12
 Functions: \sin\cos\tan\ln\log
 GreekLetters: \alpha\beta\gamma\omega
-KaTeX:
-    tex: \KaTeX
-    nolatex: There is no LaTeX command for this (yet)
+KaTeX: \KaTeX
 Lap: ab\llap{f}cd\rlap{g}h
 LeftRight: \left( x^2 \right) \left\{ x^{x^{x^{x^x}}} \right.
 LeftRightListStyling: a+\left(x+y\right)-x
@@ -108,6 +106,7 @@ UnsupportedCmds:
     tex: \err\,\frac\fracerr3\,2^\superr_\suberr\,\sqrt\sqrterr
     noThrow: 1
     errorColor: "#dd4c4c"
+    nolatex: deliberately does not compile
 VerticalSpacing:
     pre: potato<br>blah
     tex: x^{\Huge y}z

--- a/test/screenshotter/test.tex
+++ b/test/screenshotter/test.tex
@@ -1,6 +1,8 @@
 \documentclass[10pt]{article}
 
 \usepackage{amsmath,amssymb}
+\usepackage[mathscr]{eucal}
+\usepackage{eufrak}
 \usepackage[papersize={133pt,100pt},margin=0.5pt]{geometry}
 \usepackage{color}
 \usepackage{etoolbox}
@@ -8,6 +10,14 @@
 \pagestyle{empty}
 
 \newcommand{\blue}[1]{\textcolor{blue}{#1}}
+
+\DeclareRobustCommand{\KaTeX}{\mbox{%
+K\kern-.26em%
+{\sbox0 T\vbox to\ht0{\kern.05em\hbox%
+  {\fontsize{.75em}{1em}\selectfont A}%
+\vss}}%
+\kern-.23em%
+\TeX}}
 
 % Thanks to http://tex.stackexchange.com/a/26017/16923
 \newtoks\kasizetoks


### PR DESCRIPTION
Since all the math font test cases use the KaTeX logo, we need that. I started with the definition of the logo from katex.less, but tweaked that until it gave a good visual match, in particular a very similar logo width, no matter the actual numbers.

![KaTeX](https://cloud.githubusercontent.com/assets/190759/9790451/5f261e88-57d6-11e5-9802-633ae318f8aa.png)

With that logo, most tests can be compiled again, with the exception of the one containing illegal functions to test visual error reporting. That one needs to be explicitely disabled.

In particular, we can now for the first time see texcmp output from all the font test cases. Some fonts simply use a lot of unsuitable symbols in TeX, since they only have very limited font support and TeX doesn't fall back the way KaTeX does:
* MathBb: ![mathbb](https://cloud.githubusercontent.com/assets/190759/9790455/7188a6d6-57d6-11e5-8104-d36434af29ce.png)
* MathCal: ![mathcal](https://cloud.githubusercontent.com/assets/190759/9790456/7188fa3c-57d6-11e5-8205-aa06e35ce202.png)
* MathFrak: ![mathfrak](https://cloud.githubusercontent.com/assets/190759/9790458/718b4de6-57d6-11e5-97a3-53cf5ddaff08.png)
* MathScr: ![mathscr](https://cloud.githubusercontent.com/assets/190759/9790462/71a2df56-57d6-11e5-881b-07a170f12c41.png)
  That last one looks like a poor match even for the letter A up front. But I guess I'd need to use some other package in LaTeX, not sure which one. Suggestions?

Other fonts have more complete support, though, so we can actually learn something from these:
* MathBf: ![mathbf](https://cloud.githubusercontent.com/assets/190759/9790457/718a2e7a-57d6-11e5-8eb4-cd67ea0781e8.png)
* MathDefaultFonts: ![mathdefaultfonts](https://cloud.githubusercontent.com/assets/190759/9790459/718cd134-57d6-11e5-8766-54b5cff155f6.png)
* MathIt: ![mathit](https://cloud.githubusercontent.com/assets/190759/9790460/71906880-57d6-11e5-981a-59d1d8ab597a.png)
* MathRm: ![mathrm](https://cloud.githubusercontent.com/assets/190759/9790461/71a02414-57d6-11e5-8825-96a5a5fb5c9d.png)
* MathSf: ![mathsf](https://cloud.githubusercontent.com/assets/190759/9790463/71a377ae-57d6-11e5-87d3-36b6bc248c5e.png)
* MathTt: ![mathtt](https://cloud.githubusercontent.com/assets/190759/9790464/71a7d600-57d6-11e5-8e08-2860addf71f0.png)

One thing I notice is that the dotless i is positioned somewhat different in most of these tests. Another thing is that the breve diacritic over the a apparently matches the font in LaTeX: it's italic for italic, bold for bold and teletype-style for teletype. The spacing difference in the italic font looks like it might be an issue, too. Perhaps this has something to do with italic or slant correction, one way or another? Don't know much about those, unfortunately.

Feel free to open separate bug requests to keep track of any such issues you consider relevant, so we can keep track of them even after this merge request here got accepted.