### PR TITLE
Set the greedines of font functions to 2 so that e^\mathbf{x} will parse

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -462,7 +462,8 @@ defineFunction([
     // aliases
     "\\Bbb", "\\bold", "\\frak"
 ], {
-    numArgs: 1
+    numArgs: 1,
+    greediness: 2
 }, function (func, body) {
     if (func in fontAliases) {
         func = fontAliases[func];

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1259,6 +1259,10 @@ describe("A font parser", function () {
         expect(bf.value.body.value[1].value.font).toMatch("mathrm");
         expect(bf.value.body.value[2].value).toMatch("c");
     });
+    
+    it("should have the correct greediness", function() {
+        expect("e^\\mathbf{x}").toParse();
+    });
 });
 
 describe("An HTML font tree-builder", function () {


### PR DESCRIPTION
Fixes issue https://github.com/Khan/KaTeX/issues/344