### PR TITLE
Add a link to symbol/function support preview page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,13 @@ If you'd like to contribute, try contributing new symbols or functions that
 KaTeX doesn't currently support. The wiki has a page which lists [all of the
 supported
 functions](https://github.com/Khan/KaTeX/wiki/Function-Support-in-KaTeX) as 
-well as a page that describes how to [examine TeX commands and where to find
-rules](https://github.com/Khan/KaTeX/wiki/Examining-TeX) which can be quite
-useful when adding new commands. You
-can check there to see if we don't support a function you like, or try your
+well as a page that describes how to [examine TeX commands and where to find 
+rules](https://github.com/Khan/KaTeX/wiki/Examining-TeX) which can be quite 
+useful when adding new commands. There's also a user-contributed [preview page]
+(http://utensil-site.github.io/available-in-katex/)
+showing how KaTeX would render a series of symbols/functions (including the ones
+MathJax listed in their documentation and the extra ones supported by KaTeX). You
+can check them to see if we don't support a function you like, or try your
 function in the interactive demo at
 [http://khan.github.io/KaTeX/](http://khan.github.io/KaTeX/).
 


### PR DESCRIPTION
As suggested by @kevinbarabash in https://github.com/Khan/KaTeX/issues/103#issuecomment-148118466 , I've added a link to a symbol/function support preview page that I automatically generated and handcrafted in CONTRIBUTING.md.

This PR is not meant to be directly merged(though that's also possible), but opens a discussion about how to integrate this preview page into contributing guide.

The preview page currently lists all symbols and function in KaTeX wiki and MathJax document, and attempts to render them, and falls into 3 kind of results:

* successfully rendered by just the symbol itself, presented in a green cell
* can't be rendered by itself(because it's function), but can be successfully rendered by providing an proper example,  presented in a blue cell, along with the tooltip of the original TeX code of the example, that's the main handcraft part
* failed to render  (because KaTeX doesn't support them in the release yet), presented in a red cell

The page is quite self-explanatory and also includes statistics of the three kind of results.

The question left to be discussed are:

* is the preview page proper/good enough to be added to CONTRIBUTING.md ?
* should the preivew page be somewhere more official, like in a rep of KaTeX organization? (the code is not necessary good enough, because it's just a prototype, though it works nicely)
* should the introduction of the 3 places that contributors to check for symbol/function support improve wording and organization?

P.S. I've already signed the SLA.