### PR TITLE
Check screenshots on Travis using Docker and Selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ before_script:
   - docker pull selenium/standalone-chrome:2.46.0
 script:
   - npm test
-  - dockers/Screenshotter/screenshotter.sh
-  - git diff --name-only --exit-code
+  - dockers/Screenshotter/screenshotter.sh --verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: node_js
 node_js:
-- "0.11"
-- "0.10"
+  - stable
+sudo: required
+services:
+  - docker
+before_script:
+  - docker pull selenium/standalone-firefox:2.46.0
+  - docker pull selenium/standalone-chrome:2.46.0
+script:
+  - npm test
+  - dockers/Screenshotter/screenshotter.sh
+  - git diff --name-only --exit-code


### PR DESCRIPTION
Thanks to the [docker service provided by Travis CI](http://docs.travis-ci.com/user/docker/), we should be able to download and use the Selenium docker images in order to run our screenshotter and check whether all the screenshots match the images from the repository.

This fixes #300.

The Selenium bindings for JavaScript [appear to use some ES6 syntax](https://travis-ci.org/gagern/KaTeX/jobs/89607826#L549-L562) in their [latest version (2.48.2)](https://travis-ci.org/gagern/KaTeX/jobs/89607826#L264), so I bumped the node version to support this. If you disagree, we'll have to restrict the version of `selenium-webdriver` some more.