### PR TITLE
JSLint: A constructor name should start with an uppercase letter

### DIFF
--- a/dockers/texcmp/texcmp.js
+++ b/dockers/texcmp/texcmp.js
@@ -6,7 +6,7 @@ var path = require("path");
 var Q = require("q"); // To debug, pass Q_DEBUG=1 in the environment
 var pngparse = require("pngparse");
 var fft = require("ndarray-fft");
-var ndarray = require("ndarray-fft/node_modules/ndarray");
+var Ndarray = require("ndarray-fft/node_modules/ndarray");
 
 var data = require("../../test/screenshotter/ss_data");
 
@@ -248,5 +248,5 @@ function fftImage(image) {
 // Create a new matrix of preconfigured dimensions, initialized to zero
 function createMatrix() {
     var array = new Float64Array(alignWidth * alignHeight);
-    return new ndarray(array, [alignWidth, alignHeight]);
+    return new Ndarray(array, [alignWidth, alignHeight]);
 }

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -87,6 +87,7 @@ defineSymbol(math, main, rel, "\u220b", "\\owns");
 // Punctuation
 defineSymbol(math, main, punct, "\u002e", "\\ldotp");
 defineSymbol(math, main, punct, "\u22c5", "\\cdotp");
+defineSymbol(math, main, punct, "\u2026", "\\dots");
 
 // Misc Symbols
 defineSymbol(math, main, textord, "\u0023", "\\#");

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -397,6 +397,8 @@ defineSymbol(math, ams, rel, "\u21be", "\\restriction");
 
 defineSymbol(math, main, textord, "\u2018", "`");
 defineSymbol(math, main, textord, "$", "\\$");
+defineSymbol(math, main, textord, "\u20ac", "\\euro");
+defineSymbol(math, main, textord, "\u20ac", "\\€");
 defineSymbol(math, main, textord, "%", "\\%");
 defineSymbol(math, main, textord, "_", "\\_");
 defineSymbol(math, main, textord, "\u2220", "\\angle");


### PR DESCRIPTION
When building using make, this error shows up. This should fix the error without changing the scripts functionality