### PR TITLE
Force Firefox to start up with an empty page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 before_script:
   - docker pull selenium/standalone-firefox:2.48.2
   - docker pull selenium/standalone-chrome:2.48.2
+  - docker images --no-trunc
 script:
   - npm test
   - dockers/Screenshotter/screenshotter.sh --verify

--- a/dockers/Screenshotter/screenshotter.js
+++ b/dockers/Screenshotter/screenshotter.js
@@ -8,6 +8,7 @@ var net = require("net");
 var pako = require("pako");
 var path = require("path");
 var selenium = require("selenium-webdriver");
+var firefox = require("selenium-webdriver/firefox");
 
 var app = require("../../server");
 var data = require("../../test/screenshotter/ss_data");
@@ -204,6 +205,12 @@ function tryConnect() {
 var driver;
 function buildDriver() {
     var builder = new selenium.Builder().forBrowser(opts.browser);
+    var ffProfile = new firefox.Profile();
+    ffProfile.setPreference(
+        "browser.startup.homepage_override.mstone", "ignore");
+    ffProfile.setPreference("browser.startup.page", 0);
+    var ffOptions = new firefox.Options().setProfile(ffProfile);
+    builder.setFirefoxOptions(ffOptions);
     if (seleniumURL) {
         builder.usingServer(seleniumURL);
     }


### PR DESCRIPTION
Otherwise it could happen that some Mozilla page gets shown which has a minimal size larger than the 786px we're requesting.  And the screenshot will span that entire page even if the window is smaller, resulting in a failure to adjust screenshot size.

See http://kb.mozillazine.org/Browser.startup.homepage_override.mstone and http://kb.mozillazine.org/Browser.startup.page for details.

As an alternative, we could just insert a `driver.get("about:blank")` before the `takeScreenshot`, but I prefer the clean solution of not even loading the offending page at all.

Just in case, we also include the docker image digests in the travis build log, to increase chances of reproducing what we get there.

This addresses issues discussed in https://github.com/Khan/KaTeX/pull/405#issuecomment-160857796 and https://github.com/Khan/KaTeX/pull/388#issuecomment-160967346.