### PR TITLE
Fix sub- and super-scripts not being centered inside of display math

### DIFF
--- a/static/katex.less
+++ b/static/katex.less
@@ -10,6 +10,7 @@
 
     > .katex {
         display: inline-block;
+        text-align: initial;
     }
 }
 


### PR DESCRIPTION
It looks like the `text-align: center` is affecting the text in sub and
superscripts. Fixes #447

Test Plan:
 - Visit [this
   example](http://localhost:7936/?text=x%5El_%7Bi%5E%7Bl%2B1%7D%2Bi%2C%20j%5E%7Bl%2B1%7D%2Bj%2C%20d%7D)
 - Edit the HTML to add `<span class="katex-display">...</span>` around the
   `<span class="katex">` node.
 - See that the sub and superscripts are left-aligned, not centered

(It looks like we don't have a way to test this in the screenshotter for now)

@kevinb