### PR TITLE
Linebreaks

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3,15 +3,25 @@
     <head>
         <meta charset="UTF-8">
         <title>KaTeX Test</title>
-        <script src="katex.js" type="text/javascript"></script>
-        <link href="katex.css" rel="stylesheet" type="text/css">
+        <script src="../build/katex.min.js" type="text/javascript"></script>
+        <link href="../build/katex.min.css" rel="stylesheet" type="text/css">
         <link href="main.css" rel="stylesheet" type="text/css">
     </head>
     <body>
         <input type="text"
                value="(\left( x \right) \left( x^2 \right) \left( \frac{a}{b} \right) \left( \frac{a^2}{b} \right) \left( \dfrac{a}{b} \right) \left( \dfrac{a^2}{b} \right)"
                id="input" />
-        <div id="math"></div>
+        <div class="math"></div>
+
+        <div style="max-width: 460px; border: 1px solid #eee;">
+            <span>How about we try mixing some math</span>
+            <span class="math"></span>
+            <span>with some text?</span>
+        </div>
+
+        <div style="max-width: 620px;">
+            <p>This is a sentence with an equation <span class="katex"><span class="katex-mathml"><math><semantics><mrow><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup><mo>=</mo><msup><mi>c</mi><mn>2</mn></msup></mrow><annotation encoding="application/x-tex">a^2 + b^2 = c^2</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height:0.8141079999999999em;"></span><span class="strut bottom" style="height:0.897438em;vertical-align:-0.08333em;"></span><span class="base textstyle uncramped"><span class="mord"><span class="mord mathit">a</span><span class="vlist"><span style="top:-0.363em;margin-right:0.05em;"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;"></span></span><span class="reset-textstyle scriptstyle uncramped"><span class="mord mathrm">2</span></span></span><span class="baseline-fix"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;"></span></span></span></span></span><span class="mbin">+</span><span class="mord"><span class="mord mathit">b</span><span class="vlist"><span style="top:-0.363em;margin-right:0.05em;"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;"></span></span><span class="reset-textstyle scriptstyle uncramped"><span class="mord mathrm">2</span></span></span><span class="baseline-fix"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;"></span></span></span></span></span><span class="mrel">=</span><span class="mord"><span class="mord mathit">c</span><span class="vlist"><span style="top:-0.363em;margin-right:0.05em;"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;"></span></span><span class="reset-textstyle scriptstyle uncramped"><span class="mord mathrm">2</span></span></span><span class="baseline-fix"><span class="fontsize-ensurer reset-size5 size5"><span style="font-size:0em;"></span></span></span></span></span></span></span></span> and the equation is followed by some text</p>
+        </div>
         <input id="permalink" type="button" value="permalink">
         <script src="main.js" type="text/javascript"></script>
     </body>

--- a/static/katex.less
+++ b/static/katex.less
@@ -16,7 +16,7 @@
 
 .katex {
     font: normal 1.21em KaTeX_Main;
-    line-height: 1.2;
+    display: inline-block;
     white-space: nowrap;
 
     // Protect elements inside .katex from inheriting text-indent.
@@ -27,6 +27,7 @@
         // which is undesireable ("to $x$,"). Instead, adjust the .katex-html
         // style and put nowrap on the inline .katex element.
         display: inline-block;
+        white-space: initial;
     }
 
     .katex-mathml {
@@ -442,10 +443,10 @@
     }
 
     .delimsizing {
-        &.size1 { font-family: KaTeX_Size1; }
-        &.size2 { font-family: KaTeX_Size2; }
-        &.size3 { font-family: KaTeX_Size3; }
-        &.size4 { font-family: KaTeX_Size4; }
+        &.size1 { font-family: KaTeX_Size1; line-height: 1; }
+        &.size2 { font-family: KaTeX_Size2; line-height: 2; }
+        &.size3 { font-family: KaTeX_Size3; line-height: 3; }
+        &.size4 { font-family: KaTeX_Size4; line-height: 4; }
 
         &.mult {
             .delim-size1 > span {

--- a/static/main.css
+++ b/static/main.css
@@ -1,12 +1,17 @@
 body {
     margin: 0px;
     padding: 0px;
-    font-size: 72px;
+    font-size: 32px;
 }
 
 #input {
     margin: 0px;
-    font-size: 100%;
+    font-size: 16px;
     width: 100%;
     box-sizing: border-box;
+}
+
+.math.constrained {
+    margin: 80px auto;
+    max-width: 460px;
 }

--- a/static/main.js
+++ b/static/main.js
@@ -1,6 +1,11 @@
+/* eslint-disable no-console */
+/* global katex:true */
+
 function init() {
     var input = document.getElementById("input");
-    var math = document.getElementById("math");
+    var outputs = Array.prototype.slice.call(
+        document.querySelectorAll(".math")
+    );
     var permalink = document.getElementById("permalink");
 
     if ("oninput" in input) {
@@ -28,9 +33,9 @@ function init() {
 
     function reprocess() {
         try {
-            katex.render(input.value, math);
+            outputs.forEach(el => katex.render(input.value, el));
         } catch (e) {
-            if (e.__proto__ == katex.ParseError.prototype) {
+            if (e.__proto__ === katex.ParseError.prototype) {
                 console.error(e);
             } else {
                 throw e;


### PR DESCRIPTION
I'm sending this PR only to start a discussion and to hopefully communicate that some of us in the community want to help you guys reach this feature :dog:. I don't pretend to think that this implementation is all there is to it, of course.

The commit 735b307 has the relevant code.

This is testable by running:

1. `make dist`
2. `python -m SimpleHTTPServer` // in project root
3. `open http://localhost:8000/static/`

For me the standout problem to line breaks seemed to be that elements weren't getting their heights correctly set. I suppose this is due to something with how the web font is used (larger text without setting larger font size.) "X-ing" the line height for each size class however solves this problem.

The problem that this PR does not solve however is where line breaks happen. MathJax for example would be smart enough to split things up, whereas in this branch the line break is "breaking up a group." I suspect that this can be fixed with CSS, though I need to refresh my memory.
![screen shot 2016-04-27 at 18 02 11](https://cloud.githubusercontent.com/assets/646665/14858924/32dffc96-0ca2-11e6-9299-bbe92438a6c0.png)

Thoughts? I'm sure you guys had considered something like this already.