### PR TITLE
Add support for \textsc.

### DIFF
--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -406,6 +406,10 @@ var fontMap = {
         fontName: "Main-Regular",
     },
 
+    "textsc": {
+        variant: "normal",
+        fontName: "Main-Regular",
+    },
     // "mathit" is missing because it requires the use of two fonts: Main-Italic
     // and Math-Italic.  This is handled by a special case in makeOrd which ends
     // up calling mathit.

--- a/src/functions.js
+++ b/src/functions.js
@@ -492,7 +492,7 @@ defineFunction([
 
 defineFunction([
     // styles
-    "\\mathrm", "\\mathit", "\\mathbf",
+    "\\mathrm", "\\mathit", "\\mathbf", "\\textsc",
 
     // families
     "\\mathbb", "\\mathcal", "\\mathfrak", "\\mathscr", "\\mathsf",

--- a/static/katex.less
+++ b/static/katex.less
@@ -92,6 +92,11 @@
         font-style: italic;
     }
 
+    .textsc {
+        font-family: KaTeX_Main;
+        font-variant: small-caps;
+    }
+
     // This value is also used in fontMetrics.js, if you change it make sure the
     // values match.
     @ptperem: 10.0;


### PR DESCRIPTION
This is a first attempt, and may still have issues.  In particular,
I am not sure what needs to be done for MathML rendering.

Fixes Khan/KaTeX#471
