### PR TITLE
Refactor infix handling to remove depency on backtracking.

### DIFF
--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -634,6 +634,17 @@ describe("An over parser", function() {
         expect(parse.value.denom.value[0].value).toEqual("3");
     });
 
+    it("should handle nested fractions in denominator", function() {
+        var nestedOverExpression = "1 \\over {2 \\over 3}";
+        var parse = getParsed(nestedOverExpression)[0];
+        expect(parse.type).toEqual("genfrac");
+        expect(parse.value.denom.value[0].type).toEqual("genfrac");
+        expect(parse.value.denom.value[0].value.numer.value[0].value).toEqual("2");
+        expect(parse.value.denom.value[0].value.denom.value[0].value).toEqual("3");
+        expect(parse.value.numer).toBeDefined();
+        expect(parse.value.numer.value[0].value).toEqual("1");
+    });
+
     it("should fail with multiple overs in the same group", function() {
         var badMultipleOvers = "1 \\over 2 + 3 \\over 4";
         expect(badMultipleOvers).toNotParse();


### PR DESCRIPTION
Ref #250 for adding macro support.  I think it has been determined that before any macro support is added, we need to remove any dependency of using the lexer at arbitrary positions.  I have refactored the infix handling to remove such dependencies.

Currently we handle infix by scanning each list of `ParseNode`s after completion to see if there are any infixes.  This implementation just sets a parser variable once an infix is found.

I know the `defer_infix` part may be a little confusing, but this is essentially a hack to keep backward compatibility with style changes (like `\displaystyle`)--it's the same reason, I suppose, that we had to write a hack to parse infixes at the end of `parseExpression`.  We handle stylechanges a little differently than TeX (which treats style changes as inline nodes instead of wrappers) which makes it a little awkward to handle.  But I believe this is handled correctly.  Another option is to check for style changes after `var atom = this.parseAtom();` and terminate the mathlist there since style changes should _aways_ be the last node in a mathlist.

As of right now, I'm passing Jasmine and the Screenshooter.  Any ideas for adding further tests?

Other things to consider:
 - Plan for error handling and parser positions.
 - Remove parser positions from functions.  No one seems to be using it anyway.