### PR TITLE
Allow macro definitions in settings

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -21,7 +21,25 @@ function Lexer(input) {
     this.pos = 0;
 }
 
-// The resulting token returned from `lex`.
+/**
+ * The resulting token returned from `lex`.
+ *
+ * It consists of the token text plus some position information.
+ * The position information is essentially a range in an input string,
+ * but instead of referencing the bare input string, we refer to the lexer.
+ * That way it is possible to attach extra metadata to the input string,
+ * like for example a file name or similar.
+ *
+ * The position information (all three parameters) is optional,
+ * so it is OK to construct synthetic tokens if appropriate.
+ * Not providing available position information may lead to
+ * degraded error reporting, though.
+ *
+ * @param {string}  text   the text of this token
+ * @param {number=} start  the start offset, zero-based inclusive
+ * @param {number=} end    the end offset, zero-based exclusive
+ * @param {Lexer=}  lexer  the lexer which in turn holds the input string
+ */
 function Token(text, start, end, lexer) {
     this.text = text;
     this.start = start;
@@ -29,6 +47,13 @@ function Token(text, start, end, lexer) {
     this.lexer = lexer;
 }
 
+/**
+ * Given a pair of tokens (this and endToken), compute a “Token” encompassing
+ * the whole input range enclosed by these two.
+ *
+ * @param {Token}  endToken  last token of the range, inclusive
+ * @param {string} text      the text of the newly constructed token
+ */
 Token.prototype.range = function(endToken, text) {
     return new Token(text, this.start, endToken.end, this.lexer);
 };

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -55,6 +55,9 @@ function Token(text, start, end, lexer) {
  * @param {string} text      the text of the newly constructed token
  */
 Token.prototype.range = function(endToken, text) {
+    if (endToken.lexer !== this.lexer) {
+        return new Token(text); // sorry, no position information available
+    }
     return new Token(text, this.start, endToken.end, this.lexer);
 };
 

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -17,15 +17,21 @@ var ParseError = require("./ParseError");
 
 // The main lexer class
 function Lexer(input) {
-    this._input = input;
+    this.input = input;
+    this.pos = 0;
 }
 
 // The resulting token returned from `lex`.
-function Token(text, data, position) {
+function Token(text, start, end, lexer) {
     this.text = text;
-    this.data = data;
-    this.position = position;
+    this.start = start;
+    this.end = end;
+    this.lexer = lexer;
 }
+
+Token.prototype.range = function(endToken, text) {
+    return new Token(text, this.start, endToken.end, this.lexer);
+};
 
 /* The following tokenRegex
  * - matches typical whitespace (but not NBSP etc.) using its first group
@@ -52,111 +58,26 @@ var tokenRegex = new RegExp(
     ")"
 );
 
-var whitespaceRegex = /\s*/;
-
 /**
- * This function lexes a single normal token. It takes a position and
- * whether it should completely ignore whitespace or not.
+ * This function lexes a single token.
  */
-Lexer.prototype._innerLex = function(pos, ignoreWhitespace) {
-    var input = this._input;
+Lexer.prototype.lex = function() {
+    var input = this.input;
+    var pos = this.pos;
     if (pos === input.length) {
-        return new Token("EOF", null, pos);
+        return new Token("EOF", pos, pos, this);
     }
     var match = matchAt(tokenRegex, input, pos);
     if (match === null) {
         throw new ParseError(
             "Unexpected character: '" + input[pos] + "'",
-            this, pos);
-    } else if (match[2]) { // matched non-whitespace
-        return new Token(match[2], null, pos + match[2].length);
-    } else if (ignoreWhitespace) {
-        return this._innerLex(pos + match[1].length, true);
-    } else { // concatenate whitespace to a single space
-        return new Token(" ", null, pos + match[1].length);
+            new Token(input[pos], pos, pos + 1, this));
     }
-};
-
-// A regex to match a CSS color (like #ffffff or BlueViolet)
-var cssColor = /#[a-z0-9]+|[a-z]+/i;
-
-/**
- * This function lexes a CSS color.
- */
-Lexer.prototype._innerLexColor = function(pos) {
-    var input = this._input;
-
-    // Ignore whitespace
-    var whitespace = matchAt(whitespaceRegex, input, pos)[0];
-    pos += whitespace.length;
-
-    var match;
-    if ((match = matchAt(cssColor, input, pos))) {
-        // If we look like a color, return a color
-        return new Token(match[0], null, pos + match[0].length);
-    } else {
-        throw new ParseError("Invalid color", this, pos);
-    }
-};
-
-// A regex to match a dimension. Dimensions look like
-// "1.2em" or ".4pt" or "1 ex"
-var sizeRegex = /(-?)\s*(\d+(?:\.\d*)?|\.\d+)\s*([a-z]{2})/;
-
-/**
- * This function lexes a dimension.
- */
-Lexer.prototype._innerLexSize = function(pos) {
-    var input = this._input;
-
-    // Ignore whitespace
-    var whitespace = matchAt(whitespaceRegex, input, pos)[0];
-    pos += whitespace.length;
-
-    var match;
-    if ((match = matchAt(sizeRegex, input, pos))) {
-        var unit = match[3];
-        // We only currently handle "em" and "ex" units
-        if (unit !== "em" && unit !== "ex") {
-            throw new ParseError("Invalid unit: '" + unit + "'", this, pos);
-        }
-        return new Token(match[0], {
-            number: +(match[1] + match[2]),
-            unit: unit,
-        }, pos + match[0].length);
-    }
-
-    throw new ParseError("Invalid size", this, pos);
-};
-
-/**
- * This function lexes a string of whitespace.
- */
-Lexer.prototype._innerLexWhitespace = function(pos) {
-    var input = this._input;
-
-    var whitespace = matchAt(whitespaceRegex, input, pos)[0];
-    pos += whitespace.length;
-
-    return new Token(whitespace[0], null, pos);
-};
-
-/**
- * This function lexes a single token starting at `pos` and of the given mode.
- * Based on the mode, we defer to one of the `_innerLex` functions.
- */
-Lexer.prototype.lex = function(pos, mode) {
-    if (mode === "math") {
-        return this._innerLex(pos, true);
-    } else if (mode === "text") {
-        return this._innerLex(pos, false);
-    } else if (mode === "color") {
-        return this._innerLexColor(pos);
-    } else if (mode === "size") {
-        return this._innerLexSize(pos);
-    } else if (mode === "whitespace") {
-        return this._innerLexWhitespace(pos);
-    }
+    var text = match[2] || " ";
+    var start = this.pos;
+    this.pos += match[0].length;
+    var end = this.pos;
+    return new Token(text, start, end, this);
 };
 
 module.exports = Lexer;

--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -13,8 +13,7 @@ function MacroExpander(input, macros) {
 }
 
 /**
- * Expand first token while that is expandable,
- * return first non-expandable token that remains.
+ * Recursively expand first token, then return first non-expandable token.
  */
 MacroExpander.prototype.nextToken = function() {
     for (;;) {
@@ -58,7 +57,7 @@ MacroExpander.prototype.get = function(ignoreSpace) {
  * Undo the effect of the preceding call to the get method.
  * A call to this method MUST be immediately preceded and immediately followed
  * by a call to get.  Only used during mode switching, i.e. after one token
- * was got in the old mode but should bet got again in a new mode
+ * was got in the old mode but should get got again in a new mode
  * with possibly different whitespace handling.
  */
 MacroExpander.prototype.unget = function(token) {

--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -1,0 +1,60 @@
+/**
+ * This file contains the “gullet” where macros are expanded
+ * until only non-macro tokens remain.
+ */
+
+var Lexer = require("./Lexer");
+
+function MacroExpander(input, macros) {
+    this.lexer = new Lexer(input);
+    this.macros = macros || {};
+    this.stack = []; // contains tokens in REVERSE order
+    this.discardedWhiteSpace = [];
+}
+
+MacroExpander.prototype.nextToken = function() {
+    for (;;) {
+        if (this.stack.length === 0) {
+            this.stack.push(this.lexer.lex());
+        }
+        var top = this.stack.pop();
+        var name = top.text;
+        if (!(name.charAt(0) === "\\" && this.macros.hasOwnProperty(name))) {
+            return top;
+        }
+        var expansion = this.macros[name];
+        if (typeof expansion === "string") {
+            var bodyLexer = new Lexer(expansion);
+            expansion = [];
+            var tok = bodyLexer.lex();
+            while (tok.text !== "EOF") {
+                expansion.push(tok);
+                tok = bodyLexer.lex();
+            }
+            expansion.reverse();
+            this.macros[name] = expansion;
+        }
+        this.stack = this.stack.concat(expansion);
+    }
+};
+
+MacroExpander.prototype.get = function(ignoreSpace) {
+    this.discardedWhiteSpace = [];
+    var token = this.nextToken();
+    if (ignoreSpace) {
+        while (token.text === " ") {
+            this.discardedWhiteSpace.push(token);
+            token = this.nextToken();
+        }
+    }
+    return token;
+};
+
+MacroExpander.prototype.unget = function(token) {
+    this.stack.push(token);
+    while (this.discardedWhiteSpace.length !== 0) {
+        this.stack.push(this.discardedWhiteSpace.pop());
+    }
+};
+
+module.exports = MacroExpander;

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -14,7 +14,7 @@ function ParseError(message, token) {
     var start;
     var end;
 
-    if (token && token.lexer) {
+    if (token && token.lexer && token.start <= token.end) {
         // If we have the input and a position, make the error a bit fancier
 
         // Get the input

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -2,6 +2,12 @@
  * This is the ParseError class, which is the main error thrown by KaTeX
  * functions when something has gone wrong. This is used to distinguish internal
  * errors from errors in the expression that the user provided.
+ *
+ * If possible, a caller should provide a Token or ParseNode with information
+ * about where in the source string the problem occurred.
+ *
+ * @param {string} message  The error message
+ * @param {(Token|ParseNode)=} token  An object providing position information
  */
 function ParseError(message, token) {
     var error = "KaTeX parse error: " + message;

--- a/src/ParseError.js
+++ b/src/ParseError.js
@@ -3,25 +3,43 @@
  * functions when something has gone wrong. This is used to distinguish internal
  * errors from errors in the expression that the user provided.
  */
-function ParseError(message, lexer, position) {
+function ParseError(message, token) {
     var error = "KaTeX parse error: " + message;
+    var start;
+    var end;
 
-    if (lexer !== undefined && position !== undefined) {
+    if (token && token.lexer) {
         // If we have the input and a position, make the error a bit fancier
 
-        // Prepend some information
-        error += " at position " + position + ": ";
-
         // Get the input
-        var input = lexer._input;
-        // Insert a combining underscore at the correct position
-        input = input.slice(0, position) + "\u0332" +
-            input.slice(position);
+        var input = token.lexer.input;
+
+        // Prepend some information
+        start = token.start;
+        end = token.end;
+        if (start === input.length) {
+            error += " at end of input: ";
+        } else {
+            error += " at position " + (start + 1) + ": ";
+        }
+
+        // Underline token in question using combining underscores
+        var underlined = input.slice(start, end).replace(/[^]/g, "$&\u0332");
 
         // Extract some context from the input and add it to the error
-        var begin = Math.max(0, position - 15);
-        var end = position + 15;
-        error += input.slice(begin, end);
+        var left;
+        if (start > 15) {
+            left = "…" + input.slice(start - 15, start);
+        } else {
+            left = input.slice(0, start);
+        }
+        var right;
+        if (end + 15 < input.length) {
+            right = input.slice(end, end + 15) + "…";
+        } else {
+            right = input.slice(end);
+        }
+        error += left + underlined + right;
     }
 
     // Some hackery to make ParseError a prototype of Error
@@ -30,7 +48,7 @@ function ParseError(message, lexer, position) {
     self.name = "ParseError";
     self.__proto__ = ParseError.prototype;
 
-    self.position = position;
+    self.position = start;
     return self;
 }
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -46,8 +46,8 @@ var ParseError = require("./ParseError");
  * Main Parser class
  */
 function Parser(input, settings) {
-    // Make a new lexer (mouth) and macro expander (gullet)
-    // for this parser (stomach, in the language of TeX)
+    // Create a new macro expander (gullet) and (indirectly via that) also a
+    // new lexer (mouth) for this parser (stomach, in the language of TeX)
     this.gullet = new MacroExpander(input, settings.macros);
     // Store the settings for use in parsing
     this.settings = settings;

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -142,11 +142,13 @@ Parser.prototype.parseExpression = function(breakOnInfix, breakOnToken) {
     // we reached the end, a }, or a \right)
     while (true) {
         var lex = this.nextToken;
-        var pos = this.pos;
         if (endOfExpression.indexOf(lex.text) !== -1) {
             break;
         }
         if (breakOnToken && lex.text === breakOnToken) {
+            break;
+        }
+        if (breakOnInfix && functions[lex.text] && functions[lex.text].infix) {
             break;
         }
         var atom = this.parseAtom();
@@ -154,17 +156,9 @@ Parser.prototype.parseExpression = function(breakOnInfix, breakOnToken) {
             if (!this.settings.throwOnError && lex.text[0] === "\\") {
                 var errorNode = this.handleUnsupportedCmd();
                 body.push(errorNode);
-
-                pos = lex.position;
                 continue;
             }
 
-            break;
-        }
-        if (breakOnInfix && atom.type === "infix") {
-            // rewind so we can parse the infix atom again
-            this.pos = pos;
-            this.nextToken = lex;
             break;
         }
         body.push(atom);

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -654,6 +654,11 @@ Parser.prototype.parseSpecialGroup = function(modeName, optional,
     var firstToken = this.nextToken;
     var lastToken = firstToken;
     while (this.nextToken.text !== (optional ? "]" : "}")) {
+        if (this.nextToken.text === "EOF") {
+            throw new ParseError(
+                "Unexpected end of input in " + modeName,
+                firstToken.range(this.nextToken, str));
+        }
         lastToken = this.nextToken;
         str += lastToken.text;
         if (!reOnline.test(str)) {

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -23,7 +23,7 @@ function Settings(options) {
     this.displayMode = get(options.displayMode, false);
     this.throwOnError = get(options.throwOnError, true);
     this.errorColor = get(options.errorColor, "#cc0000");
-    this.macros = options.macros;
+    this.macros = options.macros || {};
 }
 
 module.exports = Settings;

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -23,6 +23,7 @@ function Settings(options) {
     this.displayMode = get(options.displayMode, false);
     this.throwOnError = get(options.throwOnError, true);
     this.errorColor = get(options.errorColor, "#cc0000");
+    this.macros = options.macros;
 }
 
 module.exports = Settings;

--- a/src/environments.js
+++ b/src/environments.js
@@ -28,10 +28,8 @@ function parseArray(parser, result) {
             row = [];
             body.push(row);
         } else {
-            // TODO: Clean up the following hack once #385 got merged
-            var pos = Math.min(parser.pos + 1, parser.lexer._input.length);
             throw new ParseError("Expected & or \\\\ or \\end",
-                                 parser.lexer, pos);
+                                 parser.nextToken);
         }
     }
     result.body = body;
@@ -106,7 +104,7 @@ defineEnvironment("array", {
         }
         throw new ParseError(
             "Unknown column alignment: " + node.value,
-            context.lexer, context.positions[1]);
+            node);
     });
     var res = {
         type: "array",

--- a/src/functions.js
+++ b/src/functions.js
@@ -55,6 +55,7 @@ var ParseError = require("./ParseError");
  *                     should parse. If the optional arguments aren't found,
  *                     `null` will be passed to the handler in their place.
  *                     (default 0)
+ *  - infix: (optional) Must be true if the function is an infix operator.
  *
  * The last argument is that implementation, the handler for the function(s).
  * It is called to handle these functions and their arguments.
@@ -91,6 +92,7 @@ function defineFunction(names, props, handler) {
         greediness: (props.greediness === undefined) ? 1 : props.greediness,
         allowedInText: !!props.allowedInText,
         numOptionalArgs: props.numOptionalArgs || 0,
+        infix: !!props.infix,
         handler: handler,
     };
     for (var i = 0; i < names.length; ++i) {
@@ -535,6 +537,7 @@ defineFunction([
 // Infix generalized fractions
 defineFunction(["\\over", "\\choose"], {
     numArgs: 0,
+    infix: true,
 }, function(context) {
     var replaceWith;
     switch (context.funcName) {

--- a/src/functions.js
+++ b/src/functions.js
@@ -456,8 +456,7 @@ defineFunction([
     if (!utils.contains(delimiters, delim.value)) {
         throw new ParseError(
             "Invalid delimiter: '" + delim.value + "' after '" +
-                context.funcName + "'",
-            context.lexer, context.positions[1]);
+            context.funcName + "'", delim);
     }
 
     // \left and \right are caught somewhere in Parser.js, which is
@@ -551,6 +550,7 @@ defineFunction(["\\over", "\\choose"], {
     return {
         type: "infix",
         replaceWith: replaceWith,
+        token: context.token,
     };
 });
 
@@ -574,9 +574,7 @@ defineFunction(["\\begin", "\\end"], {
 }, function(context, args) {
     var nameGroup = args[0];
     if (nameGroup.type !== "ordgroup") {
-        throw new ParseError(
-            "Invalid environment name",
-            context.lexer, context.positions[1]);
+        throw new ParseError("Invalid environment name", nameGroup);
     }
     var name = "";
     for (var i = 0; i < nameGroup.value.length; ++i) {
@@ -585,6 +583,6 @@ defineFunction(["\\begin", "\\end"], {
     return {
         type: "environment",
         name: name,
-        namepos: context.positions[1],
+        nameGroup: nameGroup,
     };
 });

--- a/src/parseData.js
+++ b/src/parseData.js
@@ -19,7 +19,7 @@ function ParseNode(type, value, mode, firstToken, lastToken) {
     this.type = type;
     this.value = value;
     this.mode = mode;
-    if (firstToken) {
+    if (firstToken && (!lastToken || lastToken.lexer === firstToken.lexer)) {
         this.lexer = firstToken.lexer;
         this.start = firstToken.start;
         this.end = (lastToken || firstToken).end;

--- a/src/parseData.js
+++ b/src/parseData.js
@@ -1,10 +1,15 @@
 /**
  * The resulting parse tree nodes of the parse tree.
  */
-function ParseNode(type, value, mode) {
+function ParseNode(type, value, mode, firstToken, lastToken) {
     this.type = type;
     this.value = value;
     this.mode = mode;
+    if (firstToken) {
+        this.lexer = firstToken.lexer;
+        this.start = firstToken.start;
+        this.end = (lastToken || firstToken).end;
+    }
 }
 
 module.exports = {

--- a/src/parseData.js
+++ b/src/parseData.js
@@ -1,5 +1,19 @@
 /**
  * The resulting parse tree nodes of the parse tree.
+ *
+ * It is possible to provide position information, so that a ParseNode can
+ * fulfil a role similar to a Token in error reporting.
+ * For details on the corresponding properties see Token constructor.
+ * Providing such information can lead to better error reporting.
+ *
+ * @param {string}  type       type of node, like e.g. "ordgroup"
+ * @param {?object} value      type-specific representation of the node
+ * @param {string}  mode       parse mode in action for this node,
+ *                             "math" or "text"
+ * @param {Token=} firstToken  first token of the input for this node,
+ *                             will omit position information if unset
+ * @param {Token=} lastToken   last token of the input for this node,
+ *                             will default to firstToken if unset
  */
 function ParseNode(type, value, mode, firstToken, lastToken) {
     this.type = type;

--- a/static/main.js
+++ b/static/main.js
@@ -10,13 +10,9 @@ function init() {
     }
 
     if ("addEventListener" in permalink) {
-        permalink.addEventListener("click", function() {
-            window.location.search = "?text=" + encodeURIComponent(input.value);
-        });
+        permalink.addEventListener("click", setSearch);
     } else {
-        permalink.attachEvent("click", function() {
-            window.location.search = "?text=" + encodeURIComponent(input.value);
-        });
+        permalink.attachEvent("click", setSearch);
     }
 
     var match = (/(?:^\?|&)text=([^&]*)/).exec(window.location.search);
@@ -24,11 +20,26 @@ function init() {
         input.value = decodeURIComponent(match[1]);
     }
 
+    var macros = {};
+    var options = {};
+    var reMacro = /(?:^\?|&)(?:\\|%5[Cc])([A-Za-z]+)=([^&]*)/g;
+    var macroString = "";
+    while ((match = reMacro.exec(window.location.search)) !== null) {
+        options.macros = macros;
+        macros["\\" + match[1]] = decodeURIComponent(match[2]);
+        macroString += "&" + match[0].substr(1);
+    }
+
     reprocess();
+
+    function setSearch() {
+        window.location.search =
+            "?text=" + encodeURIComponent(input.value) + macroString;
+    }
 
     function reprocess() {
         try {
-            katex.render(input.value, math);
+            katex.render(input.value, math, options);
         } catch (e) {
             if (e.__proto__ == katex.ParseError.prototype) {
                 console.error(e);

--- a/static/main.js
+++ b/static/main.js
@@ -22,9 +22,9 @@ function init() {
 
     var macros = {};
     var options = {};
-    var reMacro = /(?:^\?|&)(?:\\|%5[Cc])([A-Za-z]+)=([^&]*)/g;
+    var macroRegex = /(?:^\?|&)(?:\\|%5[Cc])([A-Za-z]+)=([^&]*)/g;
     var macroString = "";
-    while ((match = reMacro.exec(window.location.search)) !== null) {
+    while ((match = macroRegex.exec(window.location.search)) !== null) {
         options.macros = macros;
         macros["\\" + match[1]] = decodeURIComponent(match[2]);
         macroString += "&" + match[0].substr(1);

--- a/test/errors-spec.js
+++ b/test/errors-spec.js
@@ -233,6 +233,16 @@ describe("Parser.expect calls:", function() {
                    "Invalid size: '1em{…' at position 7:" +
                    " \\rule[1̲e̲m̲{̲2em}{3em}");
         });
+        it("complains about missing ] for size at end of input", function() {
+            expect("\\rule[1em").toFailWithParseError(
+                   "Unexpected end of input in size" +
+                   " at position 7: \\rule[1̲e̲m̲");
+        });
+        it("complains about missing } for color at end of input", function() {
+            expect("\\color{#123456").toFailWithParseError(
+                   "Unexpected end of input in color" +
+                   " at position 8: \\color{#̲1̲2̲3̲4̲5̲6̲");
+        });
     });
 
     describe("#parseGroup expecting }", function() {

--- a/test/errors-spec.js
+++ b/test/errors-spec.js
@@ -61,16 +61,15 @@ beforeEach(function() {
 describe("Parser:", function() {
 
     describe("#handleInfixNodes", function() {
-        // TODO: The position information here is broken, should be fixed.
         it("rejects repeated infix operators", function() {
             expect("1\\over 2\\over 3").toFailWithParseError(
-                   "only one infix operator per group at position -1: " +
-                   "1\\over 2\\over ");
+                   "only one infix operator per group at position 9: " +
+                   "1\\over 2\\̲o̲v̲e̲r̲ 3");
         });
         it("rejects conflicting infix operators", function() {
             expect("1\\over 2\\choose 3").toFailWithParseError(
-                   "only one infix operator per group at position -1: " +
-                   "1\\over 2\\choos");
+                   "only one infix operator per group at position 9: " +
+                   "1\\over 2\\̲c̲h̲o̲o̲s̲e̲ 3");
         });
     });
 
@@ -91,84 +90,85 @@ describe("Parser:", function() {
     });
 
     describe("#parseAtom", function() {
-        // TODO: The positions in the following error messages appear to be
-        // off by one, i.e. they should be one character later.
         it("rejects \\limits without operator", function() {
             expect("\\alpha\\limits\\omega").toFailWithParseError(
                    "Limit controls must follow a math operator" +
-                   " at position 6: \\alpha̲\\limits\\omega");
+                   " at position 7: \\alpha\\̲l̲i̲m̲i̲t̲s̲\\omega");
         });
         it("rejects \\limits at the beginning of the input", function() {
             expect("\\limits\\omega").toFailWithParseError(
                    "Limit controls must follow a math operator" +
-                   " at position 0: ̲\\limits\\omega");
+                   " at position 1: \\̲l̲i̲m̲i̲t̲s̲\\omega");
         });
         it("rejects double superscripts", function() {
             expect("1^2^3").toFailWithParseError(
-                   "Double superscript at position 3: 1^2̲^3");
+                   "Double superscript at position 4: 1^2^̲3");
             expect("1^{2+3}_4^5").toFailWithParseError(
-                   "Double superscript at position 9: 1^{2+3}_4̲^5");
+                   "Double superscript at position 10: 1^{2+3}_4^̲5");
         });
         it("rejects double subscripts", function() {
             expect("1_2_3").toFailWithParseError(
-                   "Double subscript at position 3: 1_2̲_3");
+                   "Double subscript at position 4: 1_2_̲3");
             expect("1_{2+3}^4_5").toFailWithParseError(
-                   "Double subscript at position 9: 1_{2+3}^4̲_5");
+                   "Double subscript at position 10: 1_{2+3}^4_̲5");
         });
     });
 
     describe("#parseImplicitGroup", function() {
         it("reports unknown environments", function() {
             expect("\\begin{foo}bar\\end{foo}").toFailWithParseError(
-                   "No such environment: foo at position 11:" +
-                   " \\begin{foo}̲bar\\end{foo}");
+                   "No such environment: foo at position 7:" +
+                   " \\begin{̲f̲o̲o̲}̲bar\\end{foo}");
         });
         it("reports mismatched environments", function() {
             expect("\\begin{pmatrix}1&2\\\\3&4\\end{bmatrix}+5")
                 .toFailWithParseError(
-                   "Mismatch: \\begin{pmatrix} matched by \\end{bmatrix}");
+                   "Mismatch: \\begin{pmatrix} matched by \\end{bmatrix}" +
+                   " at position 24: …matrix}1&2\\\\3&4\\̲e̲n̲d̲{bmatrix}+5");
         });
     });
 
     describe("#parseFunction", function() {
         it("rejects math-mode functions in text mode", function() {
-            // TODO: The position info is missing here
             expect("\\text{\\sqrt2 is irrational}").toFailWithParseError(
-                   "Can't use function '\\sqrt' in text mode");
+                "Can't use function '\\sqrt' in text mode" +
+                " at position 7: \\text{\\̲s̲q̲r̲t̲2 is irrational…");
         });
     });
 
     describe("#parseArguments", function() {
         it("complains about missing argument at end of input", function() {
             expect("2\\sqrt").toFailWithParseError(
-                   "Expected group after '\\sqrt' at position 6: 2\\sqrt̲");
+                   "Expected group after '\\sqrt' at end of input: 2\\sqrt");
         });
         it("complains about missing argument at end of group", function() {
             expect("1^{2\\sqrt}").toFailWithParseError(
-                   "Expected group after '\\sqrt' at position 9: 1^{2\\sqrt̲}");
+                   "Expected group after '\\sqrt'" +
+                   " at position 10: 1^{2\\sqrt}̲");
         });
         it("complains about functions as arguments to others", function() {
             // TODO: The position looks pretty wrong here
             expect("\\sqrt\\over2").toFailWithParseError(
                    "Got function '\\over' as argument to '\\sqrt'" +
-                   " at position 9: \\sqrt\\ove̲r2");
+                   " at position 6: \\sqrt\\̲o̲v̲e̲r̲2");
         });
     });
 
     describe("#parseArguments", function() {
         it("complains about missing argument at end of input", function() {
             expect("2\\sqrt").toFailWithParseError(
-                   "Expected group after '\\sqrt' at position 6: 2\\sqrt̲");
+                   "Expected group after '\\sqrt' at end of input: 2\\sqrt");
         });
         it("complains about missing argument at end of group", function() {
             expect("1^{2\\sqrt}").toFailWithParseError(
-                   "Expected group after '\\sqrt' at position 9: 1^{2\\sqrt̲}");
+                   "Expected group after '\\sqrt'" +
+                   " at position 10: 1^{2\\sqrt}̲");
         });
         it("complains about functions as arguments to others", function() {
             // TODO: The position looks pretty wrong here
             expect("\\sqrt\\over2").toFailWithParseError(
                    "Got function '\\over' as argument to '\\sqrt'" +
-                   " at position 9: \\sqrt\\ove̲r2");
+                   " at position 6: \\sqrt\\̲o̲v̲e̲r̲2");
         });
     });
 
@@ -183,12 +183,12 @@ describe("Parser.expect calls:", function() {
         });
         it("complains about extra \\end", function() {
             expect("x\\end{matrix}").toFailWithParseError(
-                   "Expected 'EOF', got '\\end' at position 5:" +
-                   " x\\end̲{matrix}");
+                   "Expected 'EOF', got '\\end' at position 2:" +
+                   " x\\̲e̲n̲d̲{matrix}");
         });
         it("complains about top-level \\\\", function() {
             expect("1\\\\2").toFailWithParseError(
-                   "Expected 'EOF', got '\\\\' at position 3: 1\\\\̲2");
+                   "Expected 'EOF', got '\\\\' at position 2: 1\\̲\\̲2");
         });
         it("complains about top-level &", function() {
             expect("1&2").toFailWithParseError(
@@ -199,8 +199,8 @@ describe("Parser.expect calls:", function() {
     describe("#parseImplicitGroup expecting \\right", function() {
         it("rejects missing \\right", function() {
             expect("\\left(1+2)").toFailWithParseError(
-                   "Expected '\\right', got 'EOF' at position 10:" +
-                   " \\left(1+2)̲");
+                   "Expected '\\right', got 'EOF' at end of input:" +
+                   " \\left(1+2)");
         });
         it("rejects incorrectly scoped \\right", function() {
             expect("{\\left(1+2}\\right)").toFailWithParseError(
@@ -224,32 +224,32 @@ describe("Parser.expect calls:", function() {
         });
         // Can't test for the [ of an optional group since it's optional
         it("complains about missing } for color", function() {
-            expect("\\color{#ffffff {text}").toFailWithParseError(
-                   "Expected '}', got '{' at position 16:" +
-                   " color{#ffffff {̲text}");
+            expect("\\color{#ffffff{text}").toFailWithParseError(
+                   "Invalid color: '#ffffff{…' at position 8:" +
+                   " \\color{#̲f̲f̲f̲f̲f̲f̲{̲text}");
         });
         it("complains about missing ] for size", function() {
             expect("\\rule[1em{2em}{3em}").toFailWithParseError(
-                   "Expected ']', got '{' at position 10:" +
-                   " \\rule[1em{̲2em}{3em}");
+                   "Invalid size: '1em{…' at position 7:" +
+                   " \\rule[1̲e̲m̲{̲2em}{3em}");
         });
     });
 
     describe("#parseGroup expecting }", function() {
         it("at end of file", function() {
             expect("\\sqrt{2").toFailWithParseError(
-                   "Expected '}', got 'EOF' at position 7: \\sqrt{2̲");
+                   "Expected '}', got 'EOF' at end of input: \\sqrt{2");
         });
     });
 
     describe("#parseOptionalGroup expecting ]", function() {
         it("at end of file", function() {
             expect("\\sqrt[3").toFailWithParseError(
-                   "Expected ']', got 'EOF' at position 7: \\sqrt[3̲");
+                   "Expected ']', got 'EOF' at end of input: \\sqrt[3");
         });
         it("before group", function() {
             expect("\\sqrt[3{2}").toFailWithParseError(
-                   "Expected ']', got 'EOF' at position 10: \\sqrt[3{2}̲");
+                   "Expected ']', got 'EOF' at end of input: \\sqrt[3{2}");
         });
     });
 
@@ -260,13 +260,13 @@ describe("environments.js:", function() {
     describe("parseArray", function() {
         it("rejects missing \\end", function() {
             expect("\\begin{matrix}1").toFailWithParseError(
-                   "Expected & or \\\\ or \\end at position 15:" +
-                   " \\begin{matrix}1̲");
+                   "Expected & or \\\\ or \\end at end of input:" +
+                   " \\begin{matrix}1");
         });
         it("rejects incorrectly scoped \\end", function() {
             expect("{\\begin{matrix}1}\\end{matrix}").toFailWithParseError(
                    "Expected & or \\\\\ or \\end at position 17:" +
-                   " begin{matrix}1}̲\\end{matrix}");
+                   " …\\begin{matrix}1}̲\\end{matrix}");
         });
     });
 
@@ -274,8 +274,8 @@ describe("environments.js:", function() {
         it("rejects unknown column types", function() {
             // TODO: The error position here looks strange
             expect("\\begin{array}{cba}\\end{array}").toFailWithParseError(
-                   "Unknown column alignment: b at position 18:" +
-                   " gin{array}{cba}̲\\end{array}");
+                   "Unknown column alignment: b at position 16:" +
+                   " \\begin{array}{cb̲a}\\end{array}");
         });
     });
 
@@ -298,9 +298,8 @@ describe("functions.js:", function() {
 
     describe("\\begin and \\end", function() {
         it("reject invalid environment names", function() {
-            expect("\\begin{foobar}\\end{foobar}").toFailWithParseError(
-                   "No such environment: foobar at position 14:" +
-                   " \\begin{foobar}̲\\end{foobar}");
+            expect("\\begin x\\end y").toFailWithParseError(
+                   "Invalid environment name at position 8: \\begin x̲\\end y");
         });
     });
 
@@ -311,34 +310,34 @@ describe("Lexer:", function() {
     describe("#_innerLex", function() {
         it("rejects lone surrogate char", function() {
             expect("\udcba").toFailWithParseError(
-                   "Unexpected character: '\udcba' at position 0:" +
-                    " \u0332\udcba");
+                   "Unexpected character: '\udcba' at position 1:" +
+                    " \udcba\u0332");
         });
         it("rejects lone backslash at end of input", function() {
             expect("\\").toFailWithParseError(
-                   "Unexpected character: '\\' at position 0: ̲\\");
+                   "Unexpected character: '\\' at position 1: \\̲");
         });
     });
 
     describe("#_innerLexColor", function() {
         it("reject hex notation without #", function() {
             expect("\\color{1a2b3c}{foo}").toFailWithParseError(
-                   "Invalid color at position 7: \\color{̲1a2b3c}{foo}");
+                   "Invalid color: '1…' at position 8: \\color{1̲a2b3c}{foo}");
         });
     });
 
     describe("#_innerLexSize", function() {
         it("reject size without unit", function() {
             expect("\\rule{0}{2em}").toFailWithParseError(
-                   "Invalid size at position 6: \\rule{̲0}{2em}");
+                   "Invalid size: '0' at position 7: \\rule{0̲}{2em}");
         });
         it("reject size with bogus unit", function() {
             expect("\\rule{1au}{2em}").toFailWithParseError(
-                   "Invalid unit: 'au' at position 6: \\rule{̲1au}{2em}");
+                   "Invalid unit: 'au' at position 7: \\rule{1̲a̲u̲}{2em}");
         });
         it("reject size without number", function() {
             expect("\\rule{em}{2em}").toFailWithParseError(
-                   "Invalid size at position 6: \\rule{̲em}{2em}");
+                   "Invalid size: 'e…' at position 7: \\rule{e̲m}{2em}");
         });
     });
 

--- a/test/errors-spec.js
+++ b/test/errors-spec.js
@@ -225,13 +225,13 @@ describe("Parser.expect calls:", function() {
         // Can't test for the [ of an optional group since it's optional
         it("complains about missing } for color", function() {
             expect("\\color{#ffffff{text}").toFailWithParseError(
-                   "Invalid color: '#ffffff{…' at position 8:" +
-                   " \\color{#̲f̲f̲f̲f̲f̲f̲{̲text}");
+                   "Invalid color: '#ffffff{text' at position 8:" +
+                   " \\color{#̲f̲f̲f̲f̲f̲f̲{̲t̲e̲x̲t̲}");
         });
         it("complains about missing ] for size", function() {
             expect("\\rule[1em{2em}{3em}").toFailWithParseError(
-                   "Invalid size: '1em{…' at position 7:" +
-                   " \\rule[1̲e̲m̲{̲2em}{3em}");
+                   "Unexpected end of input in size" +
+                   " at position 7: \\rule[1̲e̲m̲{̲2̲e̲m̲}̲{̲3̲e̲m̲}̲");
         });
         it("complains about missing ] for size at end of input", function() {
             expect("\\rule[1em").toFailWithParseError(
@@ -332,7 +332,8 @@ describe("Lexer:", function() {
     describe("#_innerLexColor", function() {
         it("reject hex notation without #", function() {
             expect("\\color{1a2b3c}{foo}").toFailWithParseError(
-                   "Invalid color: '1…' at position 8: \\color{1̲a2b3c}{foo}");
+                   "Invalid color: '1a2b3c'" +
+                   " at position 8: \\color{1̲a̲2̲b̲3̲c̲}{foo}");
         });
     });
 
@@ -347,7 +348,7 @@ describe("Lexer:", function() {
         });
         it("reject size without number", function() {
             expect("\\rule{em}{2em}").toFailWithParseError(
-                   "Invalid size: 'e…' at position 7: \\rule{e̲m}{2em}");
+                   "Invalid size: 'em' at position 7: \\rule{e̲m̲}{2em}");
         });
     });
 

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -57,6 +57,20 @@ var getParsed = function(expr, settings) {
     return parseTree(expr, usedSettings);
 };
 
+var stripPositions = function(expr) {
+    if (expr.lexer && typeof expr.start === "number") {
+        delete expr.lexer;
+        delete expr.start;
+        delete expr.end;
+    }
+    Object.keys(expr).forEach(function(key) {
+        if (typeof expr[key] === "object") {
+            stripPositions(expr[key]);
+        }
+    });
+    return expr;
+};
+
 beforeEach(function() {
     jasmine.addMatchers({
         toParse: function() {
@@ -154,8 +168,8 @@ describe("A parser", function() {
     });
 
     it("should ignore whitespace", function() {
-        var parseA = getParsed("    x    y    ");
-        var parseB = getParsed("xy");
+        var parseA = stripPositions(getParsed("    x    y    "));
+        var parseB = stripPositions(getParsed("xy"));
         expect(parseA).toEqual(parseB);
     });
 });
@@ -340,8 +354,8 @@ describe("A subscript and superscript parser", function() {
     });
 
     it("should produce the same thing regardless of order", function() {
-        var parseA = getParsed("x^2_3");
-        var parseB = getParsed("x_3^2");
+        var parseA = stripPositions(getParsed("x^2_3"));
+        var parseB = stripPositions(getParsed("x_3^2"));
 
         expect(parseA).toEqual(parseB);
     });
@@ -1523,7 +1537,7 @@ describe("A markup generator", function() {
 
 describe("A parse tree generator", function() {
     it("generates a tree", function() {
-        var tree = katex.__parse("\\sigma^2");
+        var tree = stripPositions(katex.__parse("\\sigma^2"));
         expect(JSON.stringify(tree)).toEqual(JSON.stringify([
             {
                 "type": "supsub",


### PR DESCRIPTION
This is the next step towards macro support in KaTeX. It doesn't do `\def` or `\newcommand` yet (as is the ultimate goal of #250), but it allows the user to declare macros as part of their settings:

```js
katex.render("\\exp\\foo", div, {macros: {"\\exp": "e^", "\\foo": "23.4x"}})
```

is equivalent to rendering `e^23.4x`, including the fact that only the `2` is the exponent here, just as you'd expect from proper TeX behavior. (You can define `\foo` as `{23.4x}` to fix this possibly unintended but compatible result.)

A [previous version of this code](https://github.com/gagern/KaTeX/compare/8496a1e40f8dfbfc8dd7d2e7b5096bd5c2b01c02...b81fcb8765bbdb77c0514c566d651a8726dde15f) has been lying around for about one year, during which it was [in active use by the CindyJS project](https://github.com/CindyJS/CindyJS/blob/f4eeb07f07ace58add34f7b4d028da81288e8d58/plugins/katex/src/js/katex-plugin.js#L107-L145). The code was discussed to some extent in https://github.com/Khan/KaTeX/issues/250#issuecomment-119358745, but according to https://github.com/Khan/KaTeX/issues/266#issuecomment-166949076 I had wanted to polish the error reporting into a pull request in its own right, and somehow more important things got in the way and I never got round to finishing that.

For this reason, the first commit of this pull request here is tightly coupled with large-scale modifications to how errors are being reported. The changes are just so tightly integrated with code that moves the parsing of special groups from the lexer to the parser that I feel that separating things again would mean a massive amount of work for little benefit. Doing the error reporting changes without the restructuring to the parser means doing error reporting for certain kinds of objects more than once. Conversely, doing the parser rewrite without a change to error reporting would mean work to carry the positions along for all places that require them. So I kindly ask you to review these changes together.

The code is fresh out of my rebase. It passes all tests. Many of the tests I modified, particularly those about error reporting, but overall (perhaps with some *very* few exceptions) I think that the quality of the error reporting has improved by this. Apart from passing tests, I'm far from convinced myself that the code is ready for merging in its current form. But I'd like to discuss my concerns, and any concerns you may have, in order to polish the code up to a mergeable form. The concerns I currently have are the following:

* Are error positions zero-based or one-based? Current code has zero-based internally and in the `position` property of the error object, but one-based in the message string. This felt most consistent with the previous situation, where many errors were underlined off by one.
* Do we still want to pass position information to functions or environments, or should it be enough that groups and tokens will carry position information?
* I left the hierarchy of test cases in `errors-spec.js` unmodified, even when I moved some of the code from the lexer to the parser. Should we adjust the file, even if doing so will make the diff harder to read? Or should we clean this up in a subsequent PR?