### PR TITLE
Make screenshotter work with docker-machine

### DIFF
--- a/dockers/Screenshotter/screenshotter.js
+++ b/dockers/Screenshotter/screenshotter.js
@@ -103,19 +103,25 @@ function check(err) {
     process.exit(1);
 }
 
-function dockerCmd() {
+function cmd() {
     var args = Array.prototype.slice.call(arguments);
+    var cmd = args.shift();
     return childProcess.execFileSync(
-        "docker", args, { encoding: "utf-8" }).replace(/\n$/, "");
+        cmd, args, { encoding: "utf-8" }).replace(/\n$/, "");
 }
 
-if (!seleniumURL && opts.container) {
+function guessDockerIPs() {
+    if (process.env.DOCKER_MACHINE_NAME) {
+        var machine = process.env.DOCKER_MACHINE_NAME;
+        seleniumIP = cmd("docker-machine", "ip", machine);
+        katexIP = cmd("docker-machine", "ssh", machine,
+            "echo ${SSH_CONNECTION%% *}");
+        return;
+    }
     try {
         // When using boot2docker, seleniumIP and katexIP are distinct.
-        seleniumIP = childProcess.execFileSync(
-            "boot2docker", ["ip"], { encoding: "utf-8" }).replace(/\n$/, "");
-        var config = childProcess.execFileSync(
-            "boot2docker", ["config"], { encoding: "utf-8" });
+        seleniumIP = cmd("boot2docker", "ip");
+        var config = cmd("boot2docker", "config");
         config = (/^HostIP = "(.*)"$/m).exec(config);
         if (!config) {
             console.error("Failed to find HostIP");
@@ -123,10 +129,14 @@ if (!seleniumURL && opts.container) {
         }
         katexIP = config[1];
     } catch (e) {
-        seleniumIP = katexIP = dockerCmd(
-            "inspect", "-f", "{{.NetworkSettings.Gateway}}", opts.container);
+        seleniumIP = katexIP = cmd("docker", "inspect",
+            "-f", "{{.NetworkSettings.Gateway}}", opts.container);
     }
-    seleniumPort = dockerCmd("port", opts.container, seleniumPort);
+}
+
+if (!seleniumURL && opts.container) {
+    guessDockerIPs();
+    seleniumPort = cmd("docker", "port", opts.container, seleniumPort);
     seleniumPort = seleniumPort.replace(/^.*:/, "");
 }
 if (!seleniumURL && seleniumIP) {

--- a/dockers/Screenshotter/screenshotter.sh
+++ b/dockers/Screenshotter/screenshotter.sh
@@ -7,6 +7,15 @@
 # suitable containers themselves, calling the screenshotter.js script
 # directly.
 
+cleanup() {
+    [[ "${container}" ]] \
+        && docker stop "${container}" >/dev/null \
+        && docker rm "${container}" >/dev/null
+    container=
+}
+
+container=
+trap cleanup EXIT
 status=0
 for browserTag in firefox:2.48.2 chrome:2.48.2; do
     browser=${browserTag%:*}
@@ -23,6 +32,6 @@ for browserTag in firefox:2.48.2 chrome:2.48.2; do
         status=1
     fi
     echo "${res} taking screenshots, stopping and removing ${container:0:12}"
-    docker stop ${container} >/dev/null && docker rm ${container} >/dev/null
+    cleanup
 done
 exit ${status}


### PR DESCRIPTION
Since [`boot2docker` has been superseded by `docker-machine`](https://docs.docker.com/engine/installation/mac/), we need this to support developers on OS X.  The changes to the bash script ensure that we clean up our containers even if taking screenshots gets hung and requires a keyboard interrupt, as happens if the IP addresses were guessed incorrectly.