### PR TITLE
Add align and align* environments which alias aligned

### DIFF
--- a/src/environments.js
+++ b/src/environments.js
@@ -184,7 +184,7 @@ defineEnvironment("cases", {
 // except it operates within math mode.
 // Note that we assume \nomallineskiplimit to be zero,
 // so that \strut@ is the same as \strut.
-defineEnvironment("aligned", {
+defineEnvironment(["aligned", "align", "align*"], {
 }, function(context) {
     var res = {
         type: "array",

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1704,6 +1704,10 @@ describe("An aligned environment", function() {
     it("should parse its input", function() {
         expect("\\begin{aligned}a&=b&c&=d\\\\e&=f\\end{aligned}")
             .toParse();
+        expect("\\begin{align}a&=b&c&=d\\\\e&=f\\end{align}")
+            .toParse();
+        expect("\\begin{align*}a&=b&c&=d\\\\e&=f\\end{align*}")
+            .toParse();
     });
 
 });


### PR DESCRIPTION
Summary:
The align/align* environments create their own math environment
and normally aren't allowed within an existing math environment
which KaTeX starts in.  The rendering of align/align* matches
the rendering of aligned with the exception of equation numbering
which KaTeX doesn't support yet.  Allowing users to use these
environments allows copy/pasting of TeX content from other sources
such as TeX documents and math appearing on the web on sites using
MathJax.

Test Plan:
- make test
- open 0.0.0.0:7936 and try the following TeX code:
  `\begin{aligned}x&=y & X&=Y & a&=b+c\\ x'&=y' & X'&=Y' & a'&=b\\ x+x'&=y+y' & X+X'&=Y+Y' & a'b&=c'b\end{aligned}`
- swap out aligned for align and align* and make sure they render the same