### PR TITLE
Upgrade less to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jasmine-core": "^2.3.4",
     "js-yaml": "^3.3.1",
     "jspngopt": "^0.1.0",
-    "less": "~1.7.5",
+    "less": "~2.7.1",
     "nomnom": "^1.8.1",
     "pako": "0.2.7",
     "selenium-webdriver": "^2.46.1",

--- a/server.js
+++ b/server.js
@@ -61,19 +61,18 @@ app.get("/katex.css", function(req, res, next) {
             return;
         }
 
-        var parser = new less.Parser({
+        less.render(data, {
             paths: ["./static"],
             filename: "katex.less",
-        });
-
-        parser.parse(data, function(err, tree) {
+        }, function(err, output) {
             if (err) {
+                console.error(String(err));
                 next(err);
                 return;
             }
 
             res.setHeader("Content-Type", "text/css");
-            res.send(tree.toCSS());
+            res.send(output.css);
         });
     });
 });


### PR DESCRIPTION
This fixes a problem where the graceful-js dependency of the old less version is incompatible with node 7, and will cause warnings on node 6. The resulting `katex.min.css` is *exactly* the same as with the previous version, so the major version upgrade does not seem to affect the outcome.

Fixes #500.