### PR TITLE
Call “npm install” automatically if package.json changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,24 @@ export UGLIFYJS = $(realpath ./node_modules/.bin/uglifyjs) \
 	--beautify \
 	ascii_only=true,beautify=false
 
-setup:
+# The prepublish script in package.json will override the following variable,
+# setting it to the empty string and thereby avoiding an infinite recursion
+NIS = .npm-install.stamp
+
+$(NIS) setup: package.json
 	npm install
+	@touch $(NIS)
 
-lint: katex.js server.js cli.js $(wildcard src/*.js) $(wildcard test/*.js) $(wildcard contrib/*/*.js) $(wildcard dockers/*/*.js)
-	./node_modules/.bin/eslint $^
+lint: $(NIS) katex.js server.js cli.js $(wildcard src/*.js) $(wildcard test/*.js) $(wildcard contrib/*/*.js) $(wildcard dockers/*/*.js)
+	./node_modules/.bin/eslint $(filter-out *.stamp,$^)
 
-build/katex.js: katex.js $(wildcard src/*.js)
+build/katex.js: katex.js $(wildcard src/*.js) $(NIS)
 	$(BROWSERIFY) $< --standalone katex > $@
 
 build/katex.min.js: build/katex.js
 	$(UGLIFYJS) < $< > $@
 
-build/katex.less.css: static/katex.less $(wildcard static/*.less)
+build/katex.less.css: static/katex.less $(wildcard static/*.less) $(NIS)
 	./node_modules/.bin/lessc $< $@
 
 build/katex.min.css: build/katex.less.css
@@ -78,10 +83,10 @@ compress: build/katex.min.js build/katex.min.css
 	@printf "Minified, gzipped css: %6d\n" "${CSSSIZE}"
 	@printf "Total:                 %6d\n" "${TOTAL}"
 
-serve:
+serve: $(NIS)
 	node server.js
 
-test:
+test: $(NIS)
 	JASMINE_CONFIG_PATH=test/jasmine.json node_modules/.bin/jasmine
 
 PERL=perl
@@ -94,7 +99,7 @@ extended_metrics:
 	cd metrics && $(PERL) ./mapping.pl | $(PYTHON) ./extract_tfms.py | $(PYTHON) ./extract_ttfs.py | $(PYTHON) ./format_json.py --width > ../src/fontMetricsData.js
 
 clean:
-	rm -rf build/*
+	rm -rf build/* $(NIS)
 
-screenshots: test/screenshotter/unicode-fonts
+screenshots: test/screenshotter/unicode-fonts $(NIS)
 	dockers/Screenshotter/screenshotter.sh

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "bin": "cli.js",
   "scripts": {
     "test": "make lint test",
-    "prepublish": "make dist"
+    "prepublish": "make NIS= dist"
   },
   "dependencies": {
     "match-at": "^0.1.0"


### PR DESCRIPTION
This adds a stamp file which is used to detect whether the `package.json` file got updated since the last `npm install`.  If so, `npm install` is run again to update all modules to the version described in `package.json`. This happens as a dependency of only those modules which actually need some npm-installed module.

Setting the corresponding make variable to the empty string disables the feature, which is used by the `make` invocation in the `prepublish` script inside `package.json` to avoid infinite loops.  It can also be used by developers working in an environment with reduced connectivity, as long as they know what they are doing.

This is in reaction to https://github.com/Khan/KaTeX/pull/503#issuecomment-232262910. @kevinbarabash, let me know if you'd prefer other names for the stamp file and/or the Makefile variable.

Can we place the stamp file inside the `build` directory, risking that a) people may copy that to their webservers (slightly unclean but little harm there I think) or might be doing `make clean` on a regular basis and would get annoyed if that caused a fresh `npm install` each time? If the stamp were in the `build` directory, I'd probably omit the leading dot.