### PR TITLE
Cursor

### DIFF
--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -53,6 +53,7 @@ var groupToType = {
     overline: "mord",
     underline: "mord",
     rule: "mord",
+    cursor: "cursor",
     leftright: "minner",
     sqrt: "mord",
     accent: "mord",

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -337,6 +337,13 @@ groupTypes.op = function(group) {
     return node;
 };
 
+groupTypes.cursor = function(group) {
+    var node = new mathMLTree.MathNode(
+        "mtext", [new mathMLTree.TextNode("|")]);
+
+    return node;
+};
+
 groupTypes.katex = function(group) {
     var node = new mathMLTree.MathNode(
         "mtext", [new mathMLTree.TextNode("KaTeX")]);

--- a/src/functions.js
+++ b/src/functions.js
@@ -200,6 +200,20 @@ defineFunction("\\rule", {
     };
 });
 
+defineFunction("\\cursor", {
+    numArgs: 1,
+    numOptionalArgs: 1,
+    argTypes: ["size", "size"],
+}, function(context, args) {
+    var shift = args[0];
+    var height = args[1];
+    return {
+        type: "cursor",
+        shift: shift && shift.value,
+        height: height.value,
+    };
+});
+
 defineFunction("\\kern", {
     numArgs: 1,
     argTypes: ["size"],

--- a/static/katex.less
+++ b/static/katex.less
@@ -92,6 +92,11 @@
         font-style: italic;
     }
 
+    .cursor {
+      display:inline-block;
+      min-height:2px;
+    }
+
     // This value is also used in fontMetrics.js, if you change it make sure the
     // values match.
     @ptperem: 10.0;
@@ -102,9 +107,9 @@
     @thickspace: 0.27778em;
 
     .textstyle {
-        > .mord {
+        > .mord, > .mord + .cursor {
             & + .mord {}
-            & + .mop { margin-left: @thinspace; }
+            & + .mop  { margin-left: @thinspace; }
             & + .mbin { margin-left: @mediumspace; }
             & + .mrel { margin-left: @thickspace; }
             & + .mopen {}
@@ -113,7 +118,7 @@
             & + .minner { margin-left: @thinspace; }
         }
 
-        > .mop {
+        > .mop, > .mop + .cursor {
             & + .mord { margin-left: @thinspace; }
             & + .mop { margin-left: @thinspace; }
             & + .mbin {}
@@ -124,7 +129,7 @@
             & + .minner { margin-left: @thinspace; }
         }
 
-        > .mbin {
+        > .mbin, > .mbin + .cursor {
             & + .mord { margin-left: @mediumspace; }
             & + .mop { margin-left: @mediumspace; }
             & + .mbin {}
@@ -135,7 +140,7 @@
             & + .minner { margin-left: @mediumspace; }
         }
 
-        > .mrel {
+        > .mrel, > .mrel + .cursor {
             & + .mord { margin-left: @thickspace; }
             & + .mop { margin-left: @thickspace; }
             & + .mbin {}
@@ -146,7 +151,7 @@
             & + .minner { margin-left: @thickspace; }
         }
 
-        > .mopen {
+        > .mopen, > .mopen + .cursor {
             & + .mord {}
             & + .mop {}
             & + .mbin {}
@@ -157,7 +162,7 @@
             & + .minner {}
         }
 
-        > .mclose {
+        > .mclose, > .mclose + .cursor {
             & + .mord {}
             & + .mop { margin-left: @thinspace; }
             & + .mbin { margin-left: @mediumspace; }
@@ -168,7 +173,7 @@
             & + .minner { margin-left: @thinspace; }
         }
 
-        > .mpunct {
+        > .mpunct, > .mpunct + .cursor {
             & + .mord { margin-left: @thinspace; }
             & + .mop { margin-left: @thinspace; }
             & + .mbin {}
@@ -179,7 +184,7 @@
             & + .minner { margin-left: @thinspace; }
         }
 
-        > .minner {
+        > .minner, > .minner + .cursor {
             & + .mord { margin-left: @thinspace; }
             & + .mop { margin-left: @thinspace; }
             & + .mbin { margin-left: @mediumspace; }
@@ -193,19 +198,24 @@
 
     .mord {
         & + .mop { margin-left: @thinspace; }
+        & + .cursor + .mop { margin-left: @thinspace; }
     }
 
     .mop {
         & + .mord { margin-left: @thinspace; }
         & + .mop { margin-left: @thinspace; }
+        & + .cursor + .mord { margin-left: @thinspace; }
+        & + .cursor + .mop { margin-left: @thinspace; }
     }
 
     .mclose {
         & + .mop { margin-left: @thinspace; }
+        & + .cursor + .mop { margin-left: @thinspace; }
     }
 
     .minner {
         & + .mop { margin-left: @thinspace; }
+        & + .cursor + .mop { margin-left: @thinspace; }
     }
 
     .reset-textstyle.textstyle { font-size: 1em; }


### PR DESCRIPTION
Going back to #358, this adds a `\cursor` command with an optional shift argument, and an argument for height (the same arguments as the `\rule` command, but without width).  I needed this for a WYSIWYG mathematics editor project [guppy](http://github.com/daniel3735928559/guppy) (see also [demo](http://daniel3735928559.github.io/guppy/)).

The original idea was to try to mess with `\kern` and `\rule` and similar to get the desired result of a vertical line that is 1 pixel thick and doesn't affect the appearance/spacing/etc. of the surrounding equation wherever it is inserted.  But part of the trouble seems to be that `\rule` gets a `.mord` class which may affect the spacing between elements if, for example, it is between a `.mbin` element and a `.mord` element.  So I ended up creating a separate command for this purpose.

Since this is not a command from standard LaTeX, I am not sure what the policy is on actually including this, but I wanted to at least document how it could be done (and/or find out if there is a better way), in case anyone else also wants this.  If there is appetite for including it, I am happy to go through the rest of the proper procedure (squashing commits, maybe adding tests, etc.) also.

If it is best not to have it in the actual repo, I would be interested in some mechanism by which this could be made into a plugin, (since as it is, I end up needing to constantly merge in updates to KaTeX to my repository, whereas if I could just pull in the latest version and have the separate plugin, this might be simplified).  
