### PR TITLE
Class

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -612,6 +612,10 @@ Parser.prototype.parseGroupOfType = function(innerMode, optional) {
     if (innerMode === "size") {
         return this.parseSizeGroup(optional);
     }
+    if (innerMode === "string") {
+        var val = this.parseStringGroup("string", optional);
+        return new ParseFuncOrArgument(val.text, false);
+    }
 
     this.switchMode(innerMode);
     if (innerMode === "text") {

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -188,8 +188,9 @@ var makeSpan = function(classes, children, color) {
 /**
  * Makes a document fragment with the given list of children.
  */
-var makeFragment = function(children) {
-    var fragment = new domTree.documentFragment(children);
+var makeFragment = function(children, classes) {
+    var fragment = new domTree.documentFragment(children, null, null, null,
+        classes);
 
     sizeElementFromChildren(fragment);
 

--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -241,6 +241,16 @@ groupTypes.text = function(group, options, prev) {
         buildExpression(group.value.body, options.reset()));
 };
 
+groupTypes.xmlClass = function(group, options, prev) {
+    var elements = buildExpression(
+        group.value.value,
+        options.withColor(),
+        prev
+    );
+
+    return new buildCommon.makeFragment(elements, [group.value.cl]);
+};
+
 groupTypes.color = function(group, options, prev) {
     var elements = buildExpression(
         group.value.value,

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -166,6 +166,16 @@ groupTypes.color = function(group, options) {
     return node;
 };
 
+groupTypes.xmlClass = function(group, options) {
+    var inner = buildExpression(group.value.value, options);
+
+    var node = new mathMLTree.MathNode("mstyle", inner);
+
+    node.setAttribute("class", group.value.cl);
+
+    return node;
+};
+
 groupTypes.supsub = function(group, options) {
     var children = [buildGroup(group.value.base, options)];
 

--- a/src/domTree.js
+++ b/src/domTree.js
@@ -133,11 +133,12 @@ span.prototype.toMarkup = function() {
  * contains children and doesn't have any HTML properties. It also keeps track
  * of a height, depth, and maxFontSize.
  */
-function documentFragment(children, height, depth, maxFontSize) {
+function documentFragment(children, height, depth, maxFontSize, classes) {
     this.children = children || [];
     this.height = height || 0;
     this.depth = depth || 0;
     this.maxFontSize = maxFontSize || 0;
+    this.classes = classes || [];
 }
 
 /**
@@ -149,7 +150,12 @@ documentFragment.prototype.toNode = function() {
 
     // Append the children
     for (var i = 0; i < this.children.length; i++) {
-        frag.appendChild(this.children[i].toNode());
+        var c = this.children[i].toNode();
+        for (var j = 0; j < this.classes.length; j++) {
+            c.setAttribute("class", c.getAttribute("class") +
+                " " + this.classes[j]);
+        }
+        frag.appendChild(c);
     }
 
     return frag;

--- a/src/functions.js
+++ b/src/functions.js
@@ -137,6 +137,29 @@ defineFunction("\\text", {
     };
 });
 
+// XML attributes
+defineFunction("\\xmlClass", {
+    numArgs: 2,
+    allowedInText: true,
+    greediness: 3,
+    argTypes: ["string", "original"],
+}, function(context, args) {
+    var cl = args[0];
+    var body = args[1];
+    // Normalize the different kinds of bodies (see \text above)
+    var inner;
+    if (body.type === "ordgroup") {
+        inner = body.value;
+    } else {
+        inner = [body];
+    }
+    return {
+        type: "xmlClass",
+        cl: cl,
+        value: inner,
+    };
+});
+
 // A two-argument custom color
 defineFunction("\\color", {
     numArgs: 2,


### PR DESCRIPTION
In a similar spirit to #506 (and for the same reason--this time as part of the plan to add mouse support to the editor), adds an `\xmlClass` function that adds adds its first argument as a class to whatever its second argument is.  For example, `\xmlClass{foo}{x}+2` will render `x+2` like normal, but the span for the `x` will have class `.foo` in addition to all its other usual classes.  

This change ended up being a little bit invasive, and I am also interested in any methods of doing the same thing more simply.
