### PR TITLE
Add --wait option to screenshotter

### DIFF
--- a/dockers/Screenshotter/screenshotter.js
+++ b/dockers/Screenshotter/screenshotter.js
@@ -69,6 +69,9 @@ var opts = require("nomnom")
         flag: true,
         help: "Check whether screenshot matches current file content",
     })
+    .option("wait", {
+        help: "Wait this many seconds between page load and screenshot",
+    })
     .parse();
 
 var listOfCases;
@@ -281,6 +284,9 @@ function takeScreenshot(key) {
 
     var url = katexURL + "test/screenshotter/test.html?" + itm.query;
     driver.get(url);
+    if (opts.wait) {
+        browserSideWait(1000 * opts.wait);
+    }
     driver.takeScreenshot().then(haveScreenshot).then(function() {
         if (--countdown === 0) {
             if (listOfFailed.length) {


### PR DESCRIPTION
Sometimes a page might not be ready when the screenshot is taken, due to fonts still being loaded or some such.  In `--verify` mode this is taken care of by repeated attempts.  But when creating a screenshot for the first time, it might be desirable to wait a given number of seconds for things to settle down.  So this commit introduces a `--wait` option to the screenshotter.

This is a spin-off from https://github.com/Khan/KaTeX/pull/502#discussion_r71964858.