### PR TITLE
Provide link to auto-render.min.js in usage example

### DIFF
--- a/contrib/auto-render/README.md
+++ b/contrib/auto-render/README.md
@@ -10,7 +10,7 @@ This extension isn't part of KaTeX proper, so the script should be separately
 included in the page:
 
 ```html
-<script src="/path/to/auto-render.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
 ```
 
 Then, call the exposed `renderMathInElement` function in a script tag


### PR DESCRIPTION
A full url to the built (browserified and minified) `auto-render.min.js` should be available for the same reason that the full url to `katex.min.js.` is available in the [main readme](https://github.com/Khan/KaTeX#usage).