### PR TITLE
\overrightarrow TeX command implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ diff.png
 /test/symgroups.log
 /test/symgroups.pdf
 /test/screenshotter/unicode-fonts
+.DS_Store
+.npm-install.stamp
+dist/

--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -51,6 +51,7 @@ var groupToType = {
     op: "mop",
     katex: "mord",
     overline: "mord",
+    overrightarrow: "mord",
     underline: "mord",
     rule: "mord",
     leftright: "minner",
@@ -928,6 +929,33 @@ groupTypes.overline = function(group, options, prev) {
     ], "firstBaseline", null, options);
 
     return makeSpan(["overline", "mord"], [vlist], options.getColor());
+};
+
+groupTypes.overrightarrow = function(group, options, prev) {
+    // Overlines are handled in the TeXbook pg 443, Rule 9.
+
+    // Build the inner group in the cramped style.
+    var innerGroup = buildGroup(group.value.body,
+            options.withStyle(options.style.cramp()));
+
+    var ruleWidth = fontMetrics.metrics.defaultRuleThickness /
+        options.style.sizeMultiplier;
+
+    // Create the line above the body
+    var line = makeSpan(
+        [options.style.reset(), Style.TEXT.cls(), "overrightarrow-line"]);
+    line.height = ruleWidth;
+    line.maxFontSize = 1.0;
+
+    // Generate the vlist, with the appropriate kerns
+    var vlist = buildCommon.makeVList([
+        {type: "elem", elem: innerGroup},
+        {type: "kern", size: 3 * ruleWidth},
+        {type: "elem", elem: line},
+        {type: "kern", size: ruleWidth},
+    ], "firstBaseline", null, options);
+
+    return makeSpan(["overrightarrow", "mord"], [vlist], options.getColor());
 };
 
 groupTypes.underline = function(group, options, prev) {

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -422,6 +422,20 @@ groupTypes.overline = function(group, options) {
     return node;
 };
 
+groupTypes.overrightarrow = function(group, options) {
+    var operator = new mathMLTree.MathNode(
+        "mo", [new mathMLTree.TextNode("\u203e")]);
+    operator.setAttribute("stretchy", "true");
+
+    var node = new mathMLTree.MathNode(
+        "mover",
+        [buildGroup(group.value.body, options),
+         operator]);
+    node.setAttribute("accent", "true");
+
+    return node;
+};
+
 groupTypes.underline = function(group, options) {
     var operator = new mathMLTree.MathNode(
         "mo", [new mathMLTree.TextNode("\u203e")]);

--- a/src/functions.js
+++ b/src/functions.js
@@ -161,6 +161,17 @@ defineFunction("\\color", {
     };
 });
 
+// An overrightarrow
+defineFunction("\\overrightarrow", {
+    numArgs: 1,
+}, function(context, args) {
+    var body = args[0];
+    return {
+        type: "overrightarrow",
+        body: body,
+    };
+});
+
 // An overline
 defineFunction("\\overline", {
     numArgs: 1,

--- a/static/katex.less
+++ b/static/katex.less
@@ -372,6 +372,36 @@
         }
     }
 
+    .overrightarrow {
+        .overrightarrow-line {
+            width: 100%;
+            position: relative;
+
+            &:before {
+                width: 100%;
+                top:-3*@mu;
+                left:0px;
+                border-bottom-style: solid;
+                border-bottom-width: 1*@mu;  
+                position: absolute;
+                content: "";
+            }
+
+            &:after {
+                content: "";
+                top: -6.5*@mu;
+                right: -1*@mu;
+                width: 0px;
+                height: 0px;
+                position: absolute;
+                border-top: 4*@mu solid transparent;
+                border-left-style: solid;
+                border-left-width: 8*@mu;
+                border-bottom: 4*@mu solid transparent;
+            }
+        }
+    }
+
     .sqrt {
         > .sqrt-sign {
             position: relative;

--- a/static/katex.less
+++ b/static/katex.less
@@ -372,31 +372,22 @@
         }
     }
 
+
+
     .overrightarrow {
         .overrightarrow-line {
             width: 100%;
+            height: 1em;
             position: relative;
+            overflow: hidden;
 
             &:before {
-                width: 100%;
-                top:-3*@mu;
-                left:0px;
-                border-bottom-style: solid;
-                border-bottom-width: 1*@mu;  
+                content: "−−−−−−−−−−−−−−−−−→";
+                right: 0.15em;
+                height: 1em;
+                text-align: right;
                 position: absolute;
-                content: "";
-            }
-
-            &:after {
-                content: "\27A4";
-                position: absolute;
-                transform: scale(0.6,0.5);
-                -webkit-transform: scale(0.6,0.5);
-                -moz-transform: scale(0.6,0.5);
-                -ms-transform: scale(0.6,0.5);
-                -o-transform: scale(0.6,0.5);
-                right:-5*@mu;
-                top:-13*@mu;
+                letter-spacing: -0.19em;
             }
         }
     }

--- a/static/katex.less
+++ b/static/katex.less
@@ -388,16 +388,11 @@
             }
 
             &:after {
-                content: "";
-                top: -6.5*@mu;
-                right: -1*@mu;
-                width: 0px;
-                height: 0px;
+                content: "\27A4";
                 position: absolute;
-                border-top: 4*@mu solid transparent;
-                border-left-style: solid;
-                border-left-width: 8*@mu;
-                border-bottom: 4*@mu solid transparent;
+                transform: scale(0.6,0.5);
+                right:-5*@mu;
+                top:-13*@mu;
             }
         }
     }

--- a/static/katex.less
+++ b/static/katex.less
@@ -391,6 +391,10 @@
                 content: "\27A4";
                 position: absolute;
                 transform: scale(0.6,0.5);
+                -webkit-transform: scale(0.6,0.5);
+                -moz-transform: scale(0.6,0.5);
+                -ms-transform: scale(0.6,0.5);
+                -o-transform: scale(0.6,0.5);
                 right:-5*@mu;
                 top:-13*@mu;
             }

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -910,6 +910,20 @@ describe("An overline parser", function() {
     });
 });
 
+describe("An overrightarrow parser", function() {
+    var overrightarrow = "\\overrightarrow{x}";
+
+    it("should not fail", function() {
+        expect(overrightarrow).toParse();
+    });
+
+    it("should produce an overline", function() {
+        var parse = getParsed(overrightarrow)[0];
+
+        expect(parse.type).toEqual("overrightarrow");
+    });
+});
+
 describe("A rule parser", function() {
     var emRule = "\\rule{1em}{2em}";
     var exRule = "\\rule{1ex}{2em}";


### PR DESCRIPTION
I followed the \overline model to implement the \overrightarrow command. The css trick is in the static/katex.less file.

![image](https://cloud.githubusercontent.com/assets/15179356/18268602/c88884b8-7424-11e6-91c2-87eac4b12946.png)
