### PR TITLE
Make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 npm-debug.log
 last.png
 diff.png
+/.npm-install.stamp
+/dist/
 /test/screenshotter/tex/
 /test/screenshotter/diff/
 /test/symgroups.tex

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 .PHONY: build dist lint setup copy serve clean metrics test zip contrib
 build: lint build/katex.min.js build/katex.min.css contrib zip compress
 
+ifeq ($(KATEX_DIST),skip)
+
+dist:
+
+else
+
 dist: build
 	rm -rf dist/
 	cp -R build/katex/ dist/
+
+endif
 
 # Export these variables for use in contrib Makefiles
 export BUILDDIR = $(realpath build)
@@ -18,7 +26,7 @@ export UGLIFYJS = $(realpath ./node_modules/.bin/uglifyjs) \
 NIS = .npm-install.stamp
 
 $(NIS) setup: package.json
-	npm install
+	KATEX_DIST=skip npm install # dependencies only, don't build
 	@touch $(NIS)
 
 lint: $(NIS) katex.js server.js cli.js $(wildcard src/*.js) $(wildcard test/*.js) $(wildcard contrib/*/*.js) $(wildcard dockers/*/*.js)


### PR DESCRIPTION
This addresses the issues raised in #544.

First we let git ignore `.npm-install.stamp` and `dist`. Adding the latter to `.gitignore` should _not_ affect npm packaging, since that is based on a whitelist in `package.json` which does mention `dist`. I tested that `npm pack .` does still include `dist` after this modification.

Then we change the `Makefile` to only fetch dependencies but do not build KaTeX itself. The make conditionals used here are not part of POSIX make but a GNU extension.  But we already use functionality not mandated by POSIX (namely many of the functions like `wildcard`), so this should not make portability any worse than it already is.
