### PR TITLE
Fix texcmp issues related to bit depth and kerning

### DIFF
--- a/dockers/texcmp/texcmp.js
+++ b/dockers/texcmp/texcmp.js
@@ -86,7 +86,7 @@ function processTestCase(key) {
         // Step 3: call "convert ... key.pdf key.png" to create key.png
         return execFile("convert", [
             "-density", dpi, "-units", "PixelsPerInch", "-flatten",
-            pdfFile, pngFile,
+            "-depth", "8", pdfFile, pngFile,
         ]);
     }).then(function() {
         console.log("Rasterized " + key);
@@ -209,6 +209,7 @@ function readPNG(file) {
     stream.on("error", onerror);
     pngparse.parseStream(stream, function(err, image) {
         if (err) {
+            console.log("Failed to load " + file);
             onerror(err);
             return;
         }

--- a/test/screenshotter/ss_data.yaml
+++ b/test/screenshotter/ss_data.yaml
@@ -59,7 +59,9 @@ FractionTest: \dfrac{a}{b}\frac{a}{b}\tfrac{a}{b}\;-\dfrac12\;1\tfrac12
 Functions: \sin\cos\tan\ln\log
 GreekLetters: \alpha\beta\gamma\omega
 KaTeX: \KaTeX
-Kern: \frac{a\kern{1em}b}{c}a\kern{1em}b\kern{1ex}c\kern{-0.25em}d
+Kern:
+    tex: \frac{a\kern{1em}b}{c}a\kern{1em}b\kern{1ex}c\kern{-0.25em}d
+    nolatex: LaTeX fails to typeset this, “Missing number, treated as zero.”
 Lap: ab\llap{f}cd\rlap{g}h
 LeftRight: \left( x^2 \right) \left\{ x^{x^{x^{x^x}}} \right.
 LeftRightListStyling: a+\left(x+y\right)-x


### PR DESCRIPTION
* Ensure bit depth 8
* Print affected file if PNG failed to read (e.g. due to wrong bit depth)
* Disable running Kern test case through TeX as doing so fails