### PR TITLE
Improved Docker for Mac support

### DIFF
--- a/dockers/Screenshotter/screenshotter.js
+++ b/dockers/Screenshotter/screenshotter.js
@@ -288,6 +288,11 @@ function takeScreenshot(key) {
     var itm = data[key];
     if (!itm) {
         console.error("Test case " + key + " not known!");
+        listOfFailed.push(key);
+        if (exitStatus === 0) {
+            exitStatus = 1;
+        }
+        oneDone();
         return;
     }
 
@@ -303,15 +308,7 @@ function takeScreenshot(key) {
     if (opts.wait) {
         browserSideWait(1000 * opts.wait);
     }
-    driver.takeScreenshot().then(haveScreenshot).then(function() {
-        if (--countdown === 0) {
-            if (listOfFailed.length) {
-                console.error("Failed: " + listOfFailed.join(" "));
-            }
-            // devServer.close(cb) will take too long.
-            process.exit(exitStatus);
-        }
-    }, check);
+    driver.takeScreenshot().then(haveScreenshot).then(oneDone, check);
 
     function haveScreenshot(img) {
         img = imageDimensions(img);
@@ -358,6 +355,16 @@ function takeScreenshot(key) {
             return promisify(fs.writeFile, file, buf).then(function() {
                 console.log(key);
             });
+        }
+    }
+
+    function oneDone() {
+        if (--countdown === 0) {
+            if (listOfFailed.length) {
+                console.error("Failed: " + listOfFailed.join(" "));
+            }
+            // devServer.close(cb) will take too long.
+            process.exit(exitStatus);
         }
     }
 }

--- a/dockers/Screenshotter/screenshotter.js
+++ b/dockers/Screenshotter/screenshotter.js
@@ -6,6 +6,7 @@ var fs = require("fs");
 var http = require("http");
 var jspngopt = require("jspngopt");
 var net = require("net");
+var os = require("os");
 var pako = require("pako");
 var path = require("path");
 var selenium = require("selenium-webdriver");
@@ -130,12 +131,21 @@ function guessDockerIPs() {
             process.exit(2);
         }
         katexIP = katexIP || config[1];
+        return;
     } catch (e) {
-        var ip = cmd("docker", "inspect",
-            "-f", "{{.NetworkSettings.Gateway}}", opts.container);
-        seleniumIP = seleniumIP || ip;
-        katexIP = katexIP || ip;
+        // Apparently no boot2docker, continue
     }
+    if (!process.env.DOCKER_HOST && os.type() === "Darwin") {
+        // Docker for Mac
+        seleniumIP = seleniumIP || "localhost";
+        katexIP = katexIP || "*any*"; // see findHostIP
+        return;
+    }
+    // Native Docker on Linux or remote Docker daemon or similar
+    var gatewayIP = cmd("docker", "inspect",
+      "-f", "{{.NetworkSettings.Gateway}}", opts.container);
+    seleniumIP = seleniumIP || gatewayIP;
+    katexIP = katexIP || gatewayIP;
 }
 
 if (!seleniumURL && opts.container) {
@@ -192,13 +202,6 @@ function startServer() {
 // Wait for container to become ready
 
 function tryConnect() {
-    if (!katexIP) {
-        katexIP = "localhost";
-    }
-    if (!katexURL) {
-        katexURL = "http://" + katexIP + ":" + katexPort + "/";
-        console.log("KaTeX URL is " + katexURL);
-    }
     if (!seleniumIP) {
         process.nextTick(buildDriver);
         return;
@@ -253,7 +256,7 @@ function setSize(reqW, reqH) {
         var actualW = img.width;
         var actualH = img.height;
         if (actualW === targetW && actualH === targetH) {
-            process.nextTick(takeScreenshots);
+            findHostIP();
             return;
         }
         if (++attempts > 5) {
@@ -270,6 +273,64 @@ function imageDimensions(img) {
         width: buf.readUInt32BE(16),
         height: buf.readUInt32BE(20),
     };
+}
+
+//////////////////////////////////////////////////////////////////////
+// Work out how to connect to host KaTeX server
+
+function findHostIP() {
+    if (!katexIP) {
+        katexIP = "localhost";
+    }
+    if (katexIP !== "*any*" || katexURL) {
+        if (!katexURL) {
+            katexURL = "http://" + katexIP + ":" + katexPort + "/";
+            console.log("KaTeX URL is " + katexURL);
+        }
+        process.nextTick(takeScreenshots);
+        return;
+    }
+
+    // Now we need to find an IP the container can connect to.
+    // First, install a server component to get notified of successful connects
+    app.get("/ss-connect.js", function(req, res, next) {
+        if (!katexURL) {
+            katexIP = req.query.ip;
+            katexURL = "http://" + katexIP + ":" + katexPort + "/";
+            console.log("KaTeX URL is " + katexURL);
+            process.nextTick(takeScreenshots);
+        }
+        res.setHeader("Content-Type", "text/javascript");
+        res.send("//OK");
+    });
+
+    // Next, enumerate all network addresses
+    var ips = [];
+    var devs = os.networkInterfaces();
+    for (var dev in devs) {
+        if (devs.hasOwnProperty(dev)) {
+            var addrs = devs[dev];
+            for (var i = 0; i < addrs.length; ++i) {
+                var addr = addrs[i].address;
+                if (/:/.test(addr)) {
+                    addr = "[" + addr + "]";
+                }
+                ips.push(addr);
+            }
+        }
+    }
+    console.log("Looking for host IP among " + ips.join(", "));
+
+    // Load a data: URI document which attempts to contact each of these IPs
+    var html = "<!doctype html>\n<html><body>\n";
+    html += ips.map(function(ip) {
+        return '<script src="http://' + ip + ':' + katexPort +
+            '/ss-connect.js?ip=' + encodeURIComponent(ip) +
+            '" defer></script>';
+    }).join("\n");
+    html += "\n</body></html>";
+    html = "data:text/html," + encodeURIComponent(html);
+    driver.get(html);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/server.js
+++ b/server.js
@@ -17,11 +17,11 @@ var serveBrowserified = function(file, standaloneName) {
     return function(req, res, next) {
         var files;
         if (Array.isArray(file)) {
-            files = file;
+            files = file.map(function(f) { return path.join(__dirname, f); });
         } else if (file.indexOf("*") !== -1) {
-            files = glob.sync(file);
+            files = glob.sync(file, {cwd: __dirname});
         } else {
-            files = [file];
+            files = [path.join(__dirname, file)];
         }
 
         var options = {};
@@ -41,7 +41,7 @@ var serveBrowserified = function(file, standaloneName) {
     };
 };
 
-app.get("/katex.js", serveBrowserified("./katex", "katex"));
+app.get("/katex.js", serveBrowserified("katex", "katex"));
 app.use("/test/jasmine",
     express["static"](
         path.dirname(
@@ -49,20 +49,21 @@ app.use("/test/jasmine",
         )
     )
 );
-app.get("/test/katex-spec.js", serveBrowserified("./test/*[Ss]pec.js"));
+app.get("/test/katex-spec.js", serveBrowserified("test/*[Ss]pec.js"));
 app.get("/contrib/auto-render/auto-render.js",
-        serveBrowserified("./contrib/auto-render/auto-render",
+        serveBrowserified("contrib/auto-render/auto-render",
                           "renderMathInElement"));
 
 app.get("/katex.css", function(req, res, next) {
-    fs.readFile("static/katex.less", {encoding: "utf8"}, function(err, data) {
+    var lessfile = path.join(__dirname, "static", "katex.less");
+    fs.readFile(lessfile, {encoding: "utf8"}, function(err, data) {
         if (err) {
             next(err);
             return;
         }
 
         less.render(data, {
-            paths: ["./static"],
+            paths: [path.join(__dirname, "static")],
             filename: "katex.less",
         }, function(err, output) {
             if (err) {


### PR DESCRIPTION
This should allow using a Docker for Mac install without the need for user intervention.

Docker for Mac is detected by looking at the operating system and the `DOCKER_HOST` environment variable. If users configure their docker host using a docker config file, we might not notice that fact. If the OS is Darwin and the environment variable is not set, we assume Docker for Mac is being used, connecting to a local Unix domain socket by default. In that case, we set the IP to connect to the Selenium server to `"localhost"` as we can't directly reach the bridge device inside the emulated Linux. In order to find an IP address which Selenium can use to connect back to KaTeX, we try connecting to all available network addresses, taking the first one where that connection succeeds.

There are two drive-by fixes in separate commits. One improves operations if the user names an incorrect test case via the `--include` command line switch. The other makes the server work if called from a directory other than the base directory of the KaTeX development tree.