### PR TITLE
Check out test fonts in screenshotter.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ before_script:
   - docker images --no-trunc
 script:
   - npm test
-  - git clone https://github.com/Khan/KaTeX-test-fonts test/screenshotter/unicode-fonts
   - dockers/Screenshotter/screenshotter.sh --verify

--- a/dockers/Screenshotter/screenshotter.sh
+++ b/dockers/Screenshotter/screenshotter.sh
@@ -14,6 +14,18 @@ cleanup() {
     container=
 }
 
+SS_DIR=$(dirname "$0")
+TOP_DIR=${SS_DIR}/../..
+FONTS_DIR=${TOP_DIR}/test/screenshotter/unicode-fonts
+if [[ ! -d "${FONTS_DIR}" ]]; then
+    echo "Cloning test fonts repository"
+    git clone https://github.com/Khan/KaTeX-test-fonts "${FONTS_DIR}" \
+        || exit 2
+fi
+pushd "${FONTS_DIR}" || exit 2
+git checkout --detach 99fa66a2da643218754c8236b9f9151cac71ba7c || exit 2
+popd || exit 2
+
 container=
 trap cleanup EXIT
 status=0


### PR DESCRIPTION
This ensures that running screenshots as indicated by the screenshotter readme will correctly render the Unicode examples, even if not run on Travis.  It also fixes the commit ID of the unicode fonts.

One alternative would have been using a git submodule.  But as many tools will initialize submodules automatically, that would mean big downloads for anyone using such a tool to clone KaTeX.

Another alternative would be tweaking the server to fetch the files on demand if the local copy is unavailable.  But that would cause additional network overhead, so grabbing the files just once should be simpler.