### PR TITLE
Allow unbraced kerns, such as \kern1em.

### DIFF
--- a/test/errors-spec.js
+++ b/test/errors-spec.js
@@ -220,7 +220,7 @@ describe("Parser.expect calls:", function() {
         });
         it("complains about missing { for size", function() {
             expect("\\rule{1em}[2em]").toFailWithParseError(
-                   "Expected '{', got '[' at position 11: \\rule{1em}[̲2em]");
+                   "Invalid size: '[' at position 11: \\rule{1em}[̲2em]");
         });
         // Can't test for the [ of an optional group since it's optional
         it("complains about missing } for color", function() {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -997,6 +997,41 @@ describe("A kern parser", function() {
         var parse = getParsed("\\kern{-1em}")[0];
         expect(parse.value.dimension.number).toBeCloseTo(-1);
     });
+
+    it("should parse positive sizes", function() {
+        var parse = getParsed("\\kern{+1em}")[0];
+        expect(parse.value.dimension.number).toBeCloseTo(1);
+    });
+});
+
+describe("A non-braced kern parser", function() {
+    var emKern = "\\kern1em";
+    var exKern = "\\kern 1 ex";
+    var badUnitRule = "\\kern1px";
+    var noNumberRule = "\\kern em";
+
+    it("should list the correct units", function() {
+        var emParse = getParsed(emKern)[0];
+        var exParse = getParsed(exKern)[0];
+
+        expect(emParse.value.dimension.unit).toEqual("em");
+        expect(exParse.value.dimension.unit).toEqual("ex");
+    });
+
+    it("should not parse invalid units", function() {
+        expect(badUnitRule).toNotParse();
+        expect(noNumberRule).toNotParse();
+    });
+
+    it("should parse negative sizes", function() {
+        var parse = getParsed("\\kern-1em")[0];
+        expect(parse.value.dimension.number).toBeCloseTo(-1);
+    });
+
+    it("should parse positive sizes", function() {
+        var parse = getParsed("\\kern+1em")[0];
+        expect(parse.value.dimension.number).toBeCloseTo(1);
+    });
 });
 
 describe("A left/right parser", function() {


### PR DESCRIPTION
This is actually the *only* syntax TeX allows; braced kern units
are invalid.