### PR TITLE
Load full-window page before adjusting browser window size

### DIFF
--- a/dockers/Screenshotter/screenshotter.js
+++ b/dockers/Screenshotter/screenshotter.js
@@ -239,6 +239,13 @@ function buildDriver() {
     }
     driver = builder.build();
     driver.manage().timeouts().setScriptTimeout(3000).then(function() {
+        var html = '<!DOCTYPE html>' +
+            '<html><head><style type="text/css">html,body{' +
+            'width:100%;height:100%;margin:0;padding:0;overflow:hidden;' +
+            '}</style></head><body><p>Test</p></body></html>';
+        html = "data:text/html," + encodeURIComponent(html);
+        return driver.get(html);
+    }).then(function() {
         setSize(targetW, targetH);
     });
 }


### PR DESCRIPTION
Experimenting with selenium-webdriver@3.0.1 and Firefox 50.1.0 I observed screenshots having a height of merely 8 pixels.  Presumably the margin or padding of an otherwise empty document.  So in order to get the actual size of the document area, the screenshotter now loads a document which fills the entire viewport.

This might be useful in the future, and perhaps might help with the hung processes described in #494 which were never fully understood.