### PR TITLE
Fix positioning in limited quirks mode

### DIFF
--- a/src/domTree.js
+++ b/src/domTree.js
@@ -88,6 +88,9 @@ span.prototype.toNode = function() {
     for (var i = 0; i < this.children.length; i++) {
         span.appendChild(this.children[i].toNode());
     }
+    if (this.children.length) {
+        span.appendChild(document.createTextNode("\u200b"));
+    }
 
     return span;
 };
@@ -132,6 +135,9 @@ span.prototype.toMarkup = function() {
     // Add the markup of the children, also as markup
     for (var i = 0; i < this.children.length; i++) {
         markup += this.children[i].toMarkup();
+    }
+    if (this.children.length) {
+        markup += "&#x200b;";
     }
 
     markup += "</span>";


### PR DESCRIPTION
This fixes #601 by adding a zero-width space to every span that contains child nodes.  The symbol avoids the “[blocks ignore line-height quirk](https://quirks.spec.whatwg.org/#the-blocks-ignore-line-height-quirk)”.

All screenshot tests render the same before and after this commit, and they also render the same if the doctype is set to HTML 4.01 transitional in order to [trigger](https://html.spec.whatwg.org/multipage/syntax.html#the-initial-insertion-mode) [limited quirks mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).