### PR TITLE
Use morgan to log requests in the dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "js-yaml": "^3.3.1",
     "jspngopt": "^0.2.0",
     "less": "~2.7.1",
+    "morgan": "^1.7.0",
     "nomnom": "^1.8.1",
     "pako": "1.0.4",
     "selenium-webdriver": "^2.48.2",

--- a/server.js
+++ b/server.js
@@ -10,7 +10,8 @@ var less = require("less");
 var app = express();
 
 if (require.main === module) {
-    app.use(express.logger());
+    app.use(require("morgan")(
+        ":date[iso] :method :url HTTP/:http-version - :status"));
 }
 
 var serveBrowserified = function(file, standaloneName) {


### PR DESCRIPTION
This is motivated by the recent switch to Express 4 in #612. Without this commit, `make serve` will print the following message:

> Error: Most middleware (like logger) is no longer bundled with Express and must be installed separately.  Please see https://github.com/senchalabs/connect#middleware.

The webpage referenced there lists morgan as the successor of the previous logger module. The format string is something I came up with myself, in an attempt to keep line length down. Feel free to suggest alternatives if you feel that some relevant information is missing. See [morgan documentation](https://github.com/expressjs/morgan/blob/master/README.md#predefined-formats) for predefined formats and tokens.

I thought the server was tested well enough by the fact that the screenshots worked, but the logger is not used in module mode, so I missed that. Sorry.