### PR TITLE
Show compressed sizes correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,12 @@ build/katex.zip: build/katex
 zip: build/katex.tar.gz build/katex.zip
 
 compress: build/katex.min.js build/katex.min.css
-	@$(eval JSSIZE!=gzip -c build/katex.min.js | wc -c)
-	@$(eval CSSSIZE!=gzip -c build/katex.min.css | wc -c)
-	@$(eval TOTAL!=echo ${JSSIZE}+${CSSSIZE} | bc)
-	@printf "Minified, gzipped js:  %6d\n" "${JSSIZE}"
-	@printf "Minified, gzipped css: %6d\n" "${CSSSIZE}"
-	@printf "Total:                 %6d\n" "${TOTAL}"
+	@JSSIZE=`gzip -c build/katex.min.js | wc -c`; \
+	CSSSIZE=`gzip -c build/katex.min.css | wc -c`; \
+	TOTAL=`echo $${JSSIZE}+$${CSSSIZE} | bc`; \
+	printf "Minified, gzipped js:  %6d\n" "$${JSSIZE}"; \
+	printf "Minified, gzipped css: %6d\n" "$${CSSSIZE}"; \
+	printf "Total:                 %6d\n" "$${TOTAL}"
 
 serve: $(NIS)
 	$(NODE) server.js


### PR DESCRIPTION
On my macOS 10.12 all the sizes used to show as zero.  Having them in a single shell invocation should avoid that problem in a portable fashion.