### PR TITLE
Describe site-provided macros in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can provide an object of options as the last argument to `katex.render` and 
 - `displayMode`: `boolean`. If `true` the math will be rendered in display mode, which will put the math in display style (so `\int` and `\sum` are large, for example), and will center the math on the page on its own line. If `false` the math will be rendered in inline mode. (default: `false`)
 - `throwOnError`: `boolean`. If `true`, KaTeX will throw a `ParseError` when it encounters an unsupported command. If `false`, KaTeX will render the unsupported command as text in the color given by `errorColor`. (default: `true`)
 - `errorColor`: `string`. A color string given in the format `"#XXX"` or `"#XXXXXX"`. This option determines the color which unsupported commands are rendered in. (default: `#cc0000`)
-- `macros`: `object`. A collection of custom macros. Each macro is a property with a name like `\name` (written `"\\name"` in JavaScript) which maps to a String that describes the expansion of the macro.
+- `macros`: `object`. A collection of custom macros. Each macro is a property with a name like `\name` (written `"\\name"` in JavaScript) which maps to a string that describes the expansion of the macro.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can provide an object of options as the last argument to `katex.render` and 
 - `displayMode`: `boolean`. If `true` the math will be rendered in display mode, which will put the math in display style (so `\int` and `\sum` are large, for example), and will center the math on the page on its own line. If `false` the math will be rendered in inline mode. (default: `false`)
 - `throwOnError`: `boolean`. If `true`, KaTeX will throw a `ParseError` when it encounters an unsupported command. If `false`, KaTeX will render the unsupported command as text in the color given by `errorColor`. (default: `true`)
 - `errorColor`: `string`. A color string given in the format `"#XXX"` or `"#XXXXXX"`. This option determines the color which unsupported commands are rendered in. (default: `#cc0000`)
-- `macros`: Object with `\name` (written `"\\name"` in JavaScript) style properties mapping to Strings that describe the expansion of the macro.
+- `macros`: `object`. A collection of custom macros. Each macro is a property with a name like `\name` (written `"\\name"` in JavaScript) which maps to a String that describes the expansion of the macro.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,17 @@ You can provide an object of options as the last argument to `katex.render` and 
 - `displayMode`: `boolean`. If `true` the math will be rendered in display mode, which will put the math in display style (so `\int` and `\sum` are large, for example), and will center the math on the page on its own line. If `false` the math will be rendered in inline mode. (default: `false`)
 - `throwOnError`: `boolean`. If `true`, KaTeX will throw a `ParseError` when it encounters an unsupported command. If `false`, KaTeX will render the unsupported command as text in the color given by `errorColor`. (default: `true`)
 - `errorColor`: `string`. A color string given in the format `"#XXX"` or `"#XXXXXX"`. This option determines the color which unsupported commands are rendered in. (default: `#cc0000`)
+- `macros`: Object with `\name` (written `"\\name"` in JavaScript) style properties mapping to Strings that describe the expansion of the macro.
 
 For example:
 
 ```js
-katex.render("c = \\pm\\sqrt{a^2 + b^2}", element, { displayMode: true });
+katex.render("c = \\pm\\sqrt{a^2 + b^2}\\in\\RR", element, {
+  displayMode: true,
+  macros: {
+    "\\RR": "\\mathbb{R}"
+  }
+});
 ```
 
 #### Automatic rendering of math on a page


### PR DESCRIPTION
As discussed in https://github.com/Khan/KaTeX/pull/493#issuecomment-272287753, the README should describe macros. Now that we have 0.7.1 released, available via CDN, and described in the README, it's time to merge this description as well.