### PR TITLE
Rephrase displayMode description to be clearer

### DIFF
--- a/src/Settings.js
+++ b/src/Settings.js
@@ -14,7 +14,7 @@ function get(option, defaultValue) {
  * The main Settings object
  *
  * The current options stored are:
- *  - displayMode: Whether the typesetter is in display mode (in which case it 
+ *  - displayMode: Whether the typesetter is in display mode (in which case it
  *                 uses displaystyle) or not (in which case it uses textstyle)
  */
 function Settings(options) {

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -14,8 +14,11 @@ function get(option, defaultValue) {
  * The main Settings object
  *
  * The current options stored are:
- *  - displayMode: Whether the typesetter is in display mode (in which case it
- *                 uses displaystyle) or not (in which case it uses textstyle)
+ *  - displayMode: Whether the expression should be typeset as inline math
+ *                 (false, the default), meaning that the math starts in
+ *                 \textstyle and is placed in an inline-block); or as display
+ *                 math (true), meaning that the math starts in \displaystyle
+ *                 and is placed in a block with vertical margin.
  */
 function Settings(options) {
     // allow null options

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -14,8 +14,8 @@ function get(option, defaultValue) {
  * The main Settings object
  *
  * The current options stored are:
- *  - displayMode: Whether the expression should be typeset by default in
- *                 textstyle or displaystyle (default false)
+ *  - displayMode: Whether the typesetter is in display mode (in which case it 
+ *                 uses displaystyle) or not (in which case it uses textstyle)
  */
 function Settings(options) {
     // allow null options


### PR DESCRIPTION
Previously was of the form "whether should be A or B (default C)", which didn't make sense. Rewritten to properly refer to the bool and map it's effects clearly.