### PR TITLE
Use utils.deflt for Settings

### DIFF
--- a/src/Settings.js
+++ b/src/Settings.js
@@ -3,12 +3,7 @@
  * default settings.
  */
 
-/**
- * Helper function for getting a default value if the value is undefined
- */
-function get(option, defaultValue) {
-    return option === undefined ? defaultValue : option;
-}
+var utils = require("./utils");
 
 /**
  * The main Settings object
@@ -20,9 +15,9 @@ function get(option, defaultValue) {
 function Settings(options) {
     // allow null options
     options = options || {};
-    this.displayMode = get(options.displayMode, false);
-    this.throwOnError = get(options.throwOnError, true);
-    this.errorColor = get(options.errorColor, "#cc0000");
+    this.displayMode = utils.deflt(options.displayMode, false);
+    this.throwOnError = utils.deflt(options.throwOnError, true);
+    this.errorColor = utils.deflt(options.errorColor, "#cc0000");
     this.macros = options.macros || {};
 }
 

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -3,7 +3,7 @@
  * default settings.
  */
 
-var utils = require("./utils");
+const utils = require("./utils");
 
 /**
  * The main Settings object


### PR DESCRIPTION
Rather than duplicate the definition of the undefined-defaulter, use the version already present in utils.

Not sure why the `macros` line uses a different pattern, but I've left it alone. Happy to amend to make it match if desired.