### PR TITLE
Support macros in auto-render

### DIFF
--- a/contrib/auto-render/README.md
+++ b/contrib/auto-render/README.md
@@ -55,7 +55,9 @@ function renderMathInElement(elem, options)
 `elem` is an HTML DOM element. The function will recursively search for text
 nodes inside this element and render the math in them.
 
-`options` is an optional object argument with the following keys:
+`options` is an optional object argument that can have the same keys as [the 
+object passed to `katex.render`](https://github.com/Khan/KaTeX/#rendering-options),
+in addition to two auto-render-specific keys:
 
 - `delimiters`: This is a list of delimiters to look for math. Each delimiter
   has three properties:
@@ -78,3 +80,7 @@ nodes inside this element and render the math in them.
 - `ignoredTags`: This is a list of DOM node types to ignore when recursing
   through. The default value is
   `["script", "noscript", "style", "textarea", "pre", "code"]`.
+
+Note that the `displayMode` property of the options object is ignored, and is 
+instead taken from the `display` key of the corresponding entry in the 
+`delimiters` key.


### PR DESCRIPTION
This PR adds support for [the `macros` option](https://github.com/Khan/KaTeX/blob/f3df1ccbac4c61efd55bec423bc8509f8d173fb2/README.md#rendering-options) to the [auto-renderer](https://github.com/Khan/KaTeX/tree/f3df1ccbac4c61efd55bec423bc8509f8d173fb2/contrib/auto-render). There is at least [some demand](http://stackoverflow.com/questions/41980446) for this feature.

The implementation propagates a `macros` object member to the eventual call to `katex.render`. Example usage:

```javascript
var renderedContainer = document.getElementById('foobar');
const katexOpts = {
    macros: {
        "\\R": "\\mathbb{R}",
    },
};
window.renderMathInElement(renderedContainer, katexOpts);
```

I've not added a test for this. The [existing tests](https://github.com/Khan/KaTeX/blob/f3df1ccbac4c61efd55bec423bc8509f8d173fb2/contrib/auto-render/auto-render-spec.js) for auto-render don't deal with the arguments to `renderMathInElement`, so I think I'd need to add a lot to have a test for this PR. Still, I can try and give it a go if someone is willing to give me some pointers 😄 