### PR TITLE
Update texcmp to ubuntu 17.04 and avoid mounted host directory

### DIFF
--- a/dockers/texcmp/Dockerfile
+++ b/dockers/texcmp/Dockerfile
@@ -1,11 +1,30 @@
-# convert from PDF to PNG with -flatten looks really bad on 14.04 LTS
-FROM ubuntu:15.04
+FROM ubuntu:17.04
 
 MAINTAINER Martin von Gagern <gagern@ma.tum.de>
 
-# Disable regular updates, but keep security updates
-RUN sed -i 's/^\(deb.*updates\)/#\1/' /etc/apt/sources.list && apt-get update
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/bin/dumb-init
 
-# Install all required packages, but try not to pull in TOO much
-RUN apt-get -qy --no-install-recommends install \
-  texlive-latex-base etoolbox imagemagick ghostscript nodejs
+# Disable regular updates, keep security updates, avoid intermediate layers
+RUN sed -i 's/^\(deb.*updates\)/#\1/' /etc/apt/sources.list \
+ && apt-get update \
+ && apt-get upgrade -y \
+ && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -qy --no-install-recommends \
+        ca-certificates \
+        etoolbox \
+        ghostscript \
+        imagemagick \
+        nodejs \
+        npm \
+        texlive-fonts-recommended \
+        texlive-latex-base \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && chmod +x /usr/bin/dumb-init
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+RUN useradd --create-home --home-dir /KaTeX katex \
+ && mkdir -p /KaTeX/dockers/texcmp
+
+# USER katex # does not work well with docker cp copying stuff into our dirs

--- a/dockers/texcmp/Dockerfile
+++ b/dockers/texcmp/Dockerfile
@@ -25,6 +25,12 @@ RUN sed -i 's/^\(deb.*updates\)/#\1/' /etc/apt/sources.list \
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 RUN useradd --create-home --home-dir /KaTeX katex \
- && mkdir -p /KaTeX/dockers/texcmp
+ && mkdir -p /KaTeX/dockers/texcmp /KaTeX/test/screenshotter
 
-# USER katex # does not work well with docker cp copying stuff into our dirs
+ADD package.json /KaTeX/dockers/texcmp/package.json
+
+RUN ( cd /KaTeX/dockers/texcmp; npm install; ) \
+ && ( cd /KaTeX/test/screenshotter; npm install js-yaml; ) \
+ && chown -R katex:katex /KaTeX
+
+USER katex

--- a/dockers/texcmp/package.json
+++ b/dockers/texcmp/package.json
@@ -3,6 +3,7 @@
   "description": "KaTeX helper to compare LaTeX output against screenshots",
   "license": "MIT",
   "dependencies": {
+    "ndarray": "1.0.18",
     "ndarray-fft": "1.0.0",
     "pngparse": "2.0.1",
     "q": "1.4.1"

--- a/dockers/texcmp/texcmp.js
+++ b/dockers/texcmp/texcmp.js
@@ -8,7 +8,7 @@ const path = require("path");
 const Q = require("q"); // To debug, pass Q_DEBUG=1 in the environment
 const pngparse = require("pngparse");
 const fft = require("ndarray-fft");
-const ndarray = require("ndarray-fft/node_modules/ndarray");
+const ndarray = require("ndarray");
 
 const data = require("../../test/screenshotter/ss_data");
 
@@ -68,6 +68,23 @@ function processTestCase(key) {
     }
     if (itm.post) {
         tex = tex + itm.post.replace("<br>", "\\\\");
+    }
+    if (itm.macros) {
+        tex = Object.keys(itm.macros).map(name => {
+            const expansion = itm.macros[name];
+            let numArgs = 0;
+            if (expansion.indexOf("#") !== -1) {
+                const stripped = expansion.replace(/##/g, "");
+                while (stripped.indexOf("#" + (numArgs + 1)) !== -1) {
+                    ++numArgs;
+                }
+            }
+            let args = "";
+            for (let i = 1; i <= numArgs; ++i) {
+                args += "#" + i;
+            }
+            return "\\def" + name + args + "{" + expansion + "}\n";
+        }).join("") + tex;
     }
     tex = template.replace(/\$.*\$/, tex.replace(/\$/g, "$$$$"));
     const texFile = path.join(tmpDir, key + ".tex");

--- a/dockers/texcmp/texcmp.js
+++ b/dockers/texcmp/texcmp.js
@@ -173,11 +173,11 @@ function processTestCase(key) {
         const uh = Math.max(browser.height + by, latex.height + ly); // u. h.
         return execFile("convert", [
             // First image: latex rendering, converted to grayscale and padded
-            "(", pngFile, "-grayscale", "Rec709Luminance",
+            "(", pngFile, "-colorspace", "Gray",
             "-extent", uw + "x" + uh + "-" + lx + "-" + ly,
             ")",
             // Second image: browser screenshot, to grayscale and padded
-            "(", browserFile, "-grayscale", "Rec709Luminance",
+            "(", browserFile, "-colorspace", "Gray",
             "-extent", uw + "x" + uh + "-" + bx + "-" + by,
             ")",
             // Third image: the per-pixel minimum of the first two images

--- a/dockers/texcmp/texcmp.sh
+++ b/dockers/texcmp/texcmp.sh
@@ -2,16 +2,35 @@
 
 set -x
 imgname=katex/texcmp
-tag=1.1
+tag=1.2
 imgid=$(docker images | awk "/${imgname//\//\\/} *${tag//./\\.}/{print \$3}")
 cd "$(dirname "$0")" || exit $?
-npm install || exit $?
 if [[ -z ${imgid} ]]; then
     docker build -t "${imgname}:${tag}" . || exit $?
 fi
-base=$(cd ../..; pwd)
-docker run --rm \
-       -v "${base}":/KaTeX \
-       -w /KaTeX/dockers/texcmp \
-       "${imgname}:${tag}" \
-       nodejs texcmp.js "$@"
+
+cd ../..
+mkdir -p test/screenshotter/{tex,diff}
+
+cleanup() {
+    [[ "${container}" ]] && false \
+        && docker stop "${container}" >/dev/null \
+        && docker rm "${container}" >/dev/null
+    container=
+}
+container=$(docker create -t -u 0:0 \
+    -w /KaTeX/dockers/texcmp \
+    "${imgname}:${tag}" \
+    bash -c "npm install \
+&& ( cd ../../test/screenshotter && npm i js-yaml; ) \
+&& nodejs texcmp.js $*")
+trap cleanup EXIT
+tar c dockers/texcmp/{texcmp.js,package.json} \
+    test/screenshotter/{ss_data.{js,yaml},images/*-firefox.png,test.tex} \
+    | docker cp - "${container}:/KaTeX"
+docker start -a "${container}"
+docker cp "${container}:/KaTeX/test/screenshotter/tex" - \
+    | ( cd test/screenshotter/tex; tar xv; ) || exit $?
+docker cp "${container}:/KaTeX/test/screenshotter/diff" - \
+    | ( cd test/screenshotter/diff; tar xv; ) || exit $?
+cleanup

--- a/dockers/texcmp/texcmp.sh
+++ b/dockers/texcmp/texcmp.sh
@@ -2,7 +2,7 @@
 
 set -x
 imgname=katex/texcmp
-tag=1.2
+tag=1.3
 imgid=$(docker images | awk "/${imgname//\//\\/} *${tag//./\\.}/{print \$3}")
 cd "$(dirname "$0")" || exit $?
 if [[ -z ${imgid} ]]; then
@@ -21,9 +21,7 @@ cleanup() {
 container=$(docker create -t -u 0:0 \
     -w /KaTeX/dockers/texcmp \
     "${imgname}:${tag}" \
-    bash -c "npm install \
-&& ( cd ../../test/screenshotter && npm i js-yaml; ) \
-&& nodejs texcmp.js $*")
+    nodejs texcmp.js "$@")
 trap cleanup EXIT
 tar c dockers/texcmp/{texcmp.js,package.json} \
     test/screenshotter/{ss_data.{js,yaml},images/*-firefox.png,test.tex} \

--- a/dockers/texcmp/texcmp.sh
+++ b/dockers/texcmp/texcmp.sh
@@ -13,7 +13,7 @@ cd ../..
 mkdir -p test/screenshotter/{tex,diff}
 
 cleanup() {
-    [[ "${container}" ]] && false \
+    [[ "${container}" ]] \
         && docker stop "${container}" >/dev/null \
         && docker rm "${container}" >/dev/null
     container=
@@ -29,8 +29,8 @@ tar c dockers/texcmp/{texcmp.js,package.json} \
     test/screenshotter/{ss_data.{js,yaml},images/*-firefox.png,test.tex} \
     | docker cp - "${container}:/KaTeX"
 docker start -a "${container}"
-docker cp "${container}:/KaTeX/test/screenshotter/tex" - \
-    | ( cd test/screenshotter/tex; tar xov; ) || exit $?
-docker cp "${container}:/KaTeX/test/screenshotter/diff" - \
-    | ( cd test/screenshotter/diff; tar xov; ) || exit $?
+docker cp "${container}:/KaTeX/test/screenshotter/tex" test/screenshotter \
+    || exit $?
+docker cp "${container}:/KaTeX/test/screenshotter/diff" test/screenshotter \
+    || exit $?
 cleanup

--- a/dockers/texcmp/texcmp.sh
+++ b/dockers/texcmp/texcmp.sh
@@ -30,7 +30,7 @@ tar c dockers/texcmp/{texcmp.js,package.json} \
     | docker cp - "${container}:/KaTeX"
 docker start -a "${container}"
 docker cp "${container}:/KaTeX/test/screenshotter/tex" - \
-    | ( cd test/screenshotter/tex; tar xv; ) || exit $?
+    | ( cd test/screenshotter/tex; tar xov; ) || exit $?
 docker cp "${container}:/KaTeX/test/screenshotter/diff" - \
-    | ( cd test/screenshotter/diff; tar xv; ) || exit $?
+    | ( cd test/screenshotter/diff; tar xov; ) || exit $?
 cleanup

--- a/test/screenshotter/ss_data.yaml
+++ b/test/screenshotter/ss_data.yaml
@@ -95,7 +95,7 @@ LimitControls: |
     \displaystyle\int\limits_2^3 3x^2\,dx + \sum\nolimits^n_{i=1}i +
     \textstyle\int\limits_x^y z
 MathAtom: a\mathrel{\mathop{=}\limits^{\blue ?}}b
-MathAtom2: \mathop{\overline\mathrm{lim}}\limits_{x\to\infty}f(x)
+MathAtom2: \mathop{\overline{\mathrm{lim}}}\limits_{x\to\infty}f(x)
 MathDefaultFonts: Ax2k\breve{a}\omega\Omega\imath+\KaTeX
 MathBb: \mathbb{Ax2k\breve{a}\omega\Omega\imath+\KaTeX}
 MathBf: \mathbf{Ax2k\breve{a}\omega\Omega\imath+\KaTeX}


### PR DESCRIPTION
* Switch to linux 17.04 in order to have a version of nodejs which understands ES6 syntax, for the sake of a consistent codebase.
* Avoid mounting the host directory, but use “docker cp” instead to transfer files between host and container.  This should avoid ownership and permission issues, and hopefully fixes #708.
* Support macros with positional arguments.
* Fix one overline example which caused LaTeX failure due to missing braces.