### PR TITLE
Implement \coloneqq, \colonequals, etc. based on mathtools and colonequals

### DIFF
--- a/src/macros.js
+++ b/src/macros.js
@@ -34,3 +34,63 @@ defineMacro("\\iff", "\\;\\Longleftrightarrow\\;");
 defineMacro("\\implies", "\\;\\Longrightarrow\\;");
 defineMacro("\\impliedby", "\\;\\Longleftarrow\\;");
 
+//////////////////////////////////////////////////////////////////////
+// mathtools.sty
+
+//\providecommand\ordinarycolon{:}
+defineMacro("\\ordinarycolon", ":");
+//\def\vcentcolon{\mathrel{\mathop\ordinarycolon}}
+//TODO(edemaine): Not yet centered. Fix via \raisebox or #726
+defineMacro("\\vcentcolon", "\\mathrel{\\mathop\\ordinarycolon}");
+// \providecommand*\dblcolon{\vcentcolon\mathrel{\mkern-.9mu}\vcentcolon}
+defineMacro("\\dblcolon", "\\vcentcolon\\mathrel{\\mkern-.9mu}\\vcentcolon");
+// \providecommand*\coloneqq{\vcentcolon\mathrel{\mkern-1.2mu}=}
+defineMacro("\\coloneqq", "\\vcentcolon\\mathrel{\\mkern-1.2mu}=");
+// \providecommand*\Coloneqq{\dblcolon\mathrel{\mkern-1.2mu}=}
+defineMacro("\\Coloneqq", "\\dblcolon\\mathrel{\\mkern-1.2mu}=");
+// \providecommand*\coloneq{\vcentcolon\mathrel{\mkern-1.2mu}\mathrel{-}}
+defineMacro("\\coloneq", "\\vcentcolon\\mathrel{\\mkern-1.2mu}\\mathrel{-}");
+// \providecommand*\Coloneq{\dblcolon\mathrel{\mkern-1.2mu}\mathrel{-}}
+defineMacro("\\Coloneq", "\\dblcolon\\mathrel{\\mkern-1.2mu}\\mathrel{-}");
+// \providecommand*\eqqcolon{=\mathrel{\mkern-1.2mu}\vcentcolon}
+defineMacro("\\eqqcolon", "=\\mathrel{\\mkern-1.2mu}\\vcentcolon");
+// \providecommand*\Eqqcolon{=\mathrel{\mkern-1.2mu}\dblcolon}
+defineMacro("\\Eqqcolon", "=\\mathrel{\\mkern-1.2mu}\\dblcolon");
+// \providecommand*\eqcolon{\mathrel{-}\mathrel{\mkern-1.2mu}\vcentcolon}
+defineMacro("\\eqcolon", "\\mathrel{-}\\mathrel{\\mkern-1.2mu}\\vcentcolon");
+// \providecommand*\Eqcolon{\mathrel{-}\mathrel{\mkern-1.2mu}\dblcolon}
+defineMacro("\\Eqcolon", "\\mathrel{-}\\mathrel{\\mkern-1.2mu}\\dblcolon");
+// \providecommand*\colonapprox{\vcentcolon\mathrel{\mkern-1.2mu}\approx}
+defineMacro("\\colonapprox", "\\vcentcolon\\mathrel{\\mkern-1.2mu}\\approx");
+// \providecommand*\Colonapprox{\dblcolon\mathrel{\mkern-1.2mu}\approx}
+defineMacro("\\Colonapprox", "\\dblcolon\\mathrel{\\mkern-1.2mu}\\approx");
+// \providecommand*\colonsim{\vcentcolon\mathrel{\mkern-1.2mu}\sim}
+defineMacro("\\colonsim", "\\vcentcolon\\mathrel{\\mkern-1.2mu}\\sim");
+// \providecommand*\Colonsim{\dblcolon\mathrel{\mkern-1.2mu}\sim}
+defineMacro("\\Colonsim", "\\dblcolon\\mathrel{\\mkern-1.2mu}\\sim");
+
+//////////////////////////////////////////////////////////////////////
+// colonequals.sty
+
+// Alternate names for mathtools's macros:
+defineMacro("\\ratio", "\\vcentcolon");
+defineMacro("\\coloncolon", "\\dblcolon");
+defineMacro("\\colonequals", "\\coloneqq");
+defineMacro("\\coloncolonequals", "\\Coloneqq");
+defineMacro("\\equalscolon", "\\eqqcolon");
+defineMacro("\\equalscoloncolon", "\\Eqqcolon");
+defineMacro("\\colonminus", "\\coloneq");
+defineMacro("\\coloncolonminus", "\\Coloneq");
+defineMacro("\\minuscolon", "\\eqcolon");
+defineMacro("\\minuscoloncolon", "\\Eqcolon");
+// \colonapprox name is same in mathtools and colonequals.
+defineMacro("\\coloncolonapprox", "\\Colonapprox");
+// \colonsim name is same in mathtools and colonequals.
+defineMacro("\\coloncolonsim", "\\Colonsim");
+
+// Additional macros, implemented by analogy with mathtools definitions:
+defineMacro("\\simcolon", "\\sim\\mathrel{\\mkern-1.2mu}\\vcentcolon");
+defineMacro("\\simcoloncolon", "\\sim\\mathrel{\\mkern-1.2mu}\\dblcolon");
+defineMacro("\\approxcolon", "\\approx\\mathrel{\\mkern-1.2mu}\\vcentcolon");
+defineMacro("\\approxcoloncolon",
+            "\\approx\\mathrel{\\mkern-1.2mu}\\dblcolon");


### PR DESCRIPTION
I implemented the following commands from `mathtools.sty`, using macros with exactly their definitions in `mathtools.sty`:

```latex
\begin{matrix}
x\vcentcolon x \dblcolon x \coloneqq x \coloneq x \Coloneqq x \Coloneq x \\
x \eqqcolon x \Eqqcolon x \eqcolon x \Eqcolon x \\
x \colonapprox x \colonsim x \Colonapprox x \Colonsim x
\end{matrix}
```

![coloneqq](https://user-images.githubusercontent.com/2218736/27006559-eae9dfec-4e04-11e7-8df9-75bc5bb070c5.png)

I also implemented the following commands from `colonequals.sty`, as aliases to the `mathtools.sty` definitions, and adding a couple analogous definitions when the corresponding symbol wasn't already in `mathtools.sty`:

```latex
\begin{matrix}
x\ratio x \coloncolon x \colonequals x \coloncolonequals x \equalscolon x \equalscoloncolon x \\
x \colonminus x \coloncolonminus x \minuscolon x \minuscoloncolon x \\
x \colonapprox x \colonsim x \coloncolonapprox x \coloncolonsim x \\
x \simcolon x \simcoloncolon x \approxcolon x \approxcoloncolon x
\end{matrix}
```

![colonequals](https://user-images.githubusercontent.com/2218736/27006560-ed6e471c-4e04-11e7-9370-d0f0ac8e589f.png)

The colon will get more centered once we fix #726, or via manual tweaking via `\raisebox` (#685).  But that is independent of this PR, which at least makes the commands available now, as suggested in #657.