### PR TITLE
Make auto-render example file run in-place in repository

### DIFF
--- a/contrib/auto-render/index.html
+++ b/contrib/auto-render/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Auto-render test</title>
-    <script src="/katex.js" type="text/javascript"></script>
-    <link href="/katex.css" rel="stylesheet" type="text/css">
-    <script src="./auto-render.js" type="text/javascript"></script>
+    <script src="../../dist/katex.js" type="text/javascript"></script>
+    <link href="../../dist/katex.css" rel="stylesheet" type="text/css">
+    <script src="../../dist/contrib/auto-render.min.js" type="text/javascript"></script>
     <style type="text/css">
       body {
           margin: 0px;


### PR DESCRIPTION
I ran into this when trying to test #656.  This will make future autorender tests easier, but also make it easier for someone checking out the repo to just try out the example.  I don't think it breaks any other settings for the HTML, but please correct me if I'm wrong (e.g. if it's accessible on `https://khan.github.io/KaTeX/` somehow).

I can't imagine it ever working as written, in particular because `auto-render.js` uses `require`, so it can't run directly in a browser -- you need to run the compiled version that ends up in `dist`.