### PR TITLE
Fix high contrast mode better, thanks to @GeeLaw

### DIFF
--- a/static/katex.less
+++ b/static/katex.less
@@ -22,8 +22,9 @@
     // Protect elements inside .katex from inheriting text-indent.
     text-indent: 0;
 
-    // Prevent background resetting in Windows's high-contrast mode.
-    -ms-high-contrast-adjust: none !important;
+    // Prevent background resetting on elements in Windows's high-contrast
+    // mode, while still allowing background/foreground setting on root .katex
+    * { -ms-high-contrast-adjust: none !important; }
 
     .katex-html {
         // Making .katex inline-block allows line breaks before and after,


### PR DESCRIPTION
See https://github.com/Khan/KaTeX/issues/716#issuecomment-308818105

I tested again in Windows 10 High Contrast mode, and it looks fine (though admittedly like the last PR, #724).  I buy the argument that this behaves better in terms of overrides, though.