### PR TITLE
Show correct browser support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,10 +92,10 @@ created it, add a screenshot test. See
 
 #### Testing in other browsers
 
-KaTeX supports all major browsers, including IE 8 and newer. Unfortunately, it
+KaTeX supports all major browsers, including IE 9 and newer. Unfortunately, it
 is hard to test new changes in many browsers. If you can, please test your
 changes in as many browsers as possible. In particular, if you make CSS changes,
-try to test in IE 8, using [modern.ie](http://modern.ie) VMs.
+try to test in IE 9, using [modern.ie](http://modern.ie) VMs.
 
 ## Style guide
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ KaTeX is a fast, easy-to-use JavaScript library for TeX math rendering on the we
  * **Self contained:** KaTeX has no dependencies and can easily be bundled with your website resources.
  * **Server side rendering:** KaTeX produces the same output regardless of browser or environment, so you can pre-render expressions using Node.js and send them as plain HTML.
 
-KaTeX supports all major browsers, including Chrome, Safari, Firefox, Opera, and IE 8 - IE 11. A list of supported commands can be found on the [wiki](https://github.com/Khan/KaTeX/wiki/Function-Support-in-KaTeX).
+KaTeX supports all major browsers, including Chrome, Safari, Firefox, Opera, Edge, and IE 9 - IE 11. A list of supported commands can be found on the [wiki](https://github.com/Khan/KaTeX/wiki/Function-Support-in-KaTeX).
 
 ## Usage
 


### PR DESCRIPTION
KaTeX runs in IE 9 but not in IE 8. This PR edits the README and
Contributing files to reflect that fact.

Resolves issue #377.