### PR TITLE
Fix \boxed

### DIFF
--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -1604,7 +1604,7 @@ groupTypes.enclose = function(group, options) {
         {type: "elem", elem: img, shift: imgShift},
     ], "individualShift", null, options);
 
-    if (img.height > vlist.maxFontSize) {
+    if (img.height > vlist.maxFontSize && inner.maxFontSize <= 1.0) {
         // Correct for an issue in makeVList. It placed the image top at
         // the top of the line box created by a 1 em maxFontSize.
         vlist.children[1].style.top = -(inner.height + pad - 0.9 / scale)

--- a/src/stretchy.js
+++ b/src/stretchy.js
@@ -173,6 +173,10 @@ const encloseSpan = function(inner, isCharBox, label, pad, options) {
 
     if (/cancel/.test(label) && isCharBox) {
         img.maxFontSize = 1.2; // Make line box tall enough for image to fit.
+    } else if (label === "fbox" && inner.maxFontSize > 1.0) {
+        img.maxFontSize = 1.12 * inner.maxFontSize;
+        // Bug: This will shift the whole line downward on the screen.
+        // TODO(ron): Find a better way. Fix makeVList, perhaps.
     } else {
         img.maxFontSize = 1;
     }


### PR DESCRIPTION
A temporary patch for `\boxed`. When the box contains a large font, `\boxed`
now will pass a large value of maxFontSize to makeVList. So the box will
always be located correctly relative to the subject matter. On the other hand, 
the whole line may be pushed downward on the screen.

If the all fonts inside the box are <= 1.0 em, then `\boxed` acts just as
in PR #670, a method which does not displace the line.

To resolve all the problems, we first need to resolve issue #746.