### PR TITLE
Remove endpoint with not transpiled js in dev server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,8 +47,9 @@ function serveBrowserified(file, standaloneName, doBabelify) {
 }
 
 function twoBrowserified(url, file, standaloneName) {
-    app.get(url, serveBrowserified(file, standaloneName, false));
-    app.get("/babel" + url, serveBrowserified(file, standaloneName, true));
+    // we should always transpile all js files
+    // in order to support all ES2015 features
+    app.get(url, serveBrowserified(file, standaloneName, true));
 }
 
 function twoUse(url, handler) {


### PR DESCRIPTION
In order to merge #679 we cannot continue with not transpiled endpoint in server.js development environment because even most up to date browser still don't support many ES6 features etc yet.   
I did not remove the old code so we can role back when we have a proper browser support.