### PR TITLE
rename parseData.js to ParseNode.js and export ParseNode as the default

### DIFF
--- a/src/ParseNode.js
+++ b/src/ParseNode.js
@@ -15,7 +15,7 @@
  * @param {Token=} lastToken   last token of the input for this node,
  *                             will default to firstToken if unset
  */
-class ParseNode {
+export default class ParseNode {
     constructor(type, value, mode, firstToken, lastToken) {
         this.type = type;
         this.value = value;
@@ -27,8 +27,3 @@ class ParseNode {
         }
     }
 }
-
-module.exports = {
-    ParseNode: ParseNode,
-};
-

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -5,7 +5,7 @@ import MacroExpander from "./MacroExpander";
 import symbols from "./symbols";
 import utils from "./utils";
 import { cjkRegex } from "./unicodeRegexes";
-import { ParseNode } from "./parseData";
+import ParseNode from "./ParseNode";
 import ParseError from "./ParseError";
 
 /**

--- a/src/environments.js
+++ b/src/environments.js
@@ -1,5 +1,5 @@
 /* eslint no-constant-condition:0 */
-import { ParseNode } from "./parseData";
+import ParseNode from "./ParseNode";
 import ParseError from "./ParseError";
 
 /**

--- a/src/functions.js
+++ b/src/functions.js
@@ -1,6 +1,6 @@
 import utils from "./utils";
 import ParseError from "./ParseError";
-import { ParseNode } from "./parseData";
+import ParseNode from "./ParseNode";
 
 /* This file contains a list of functions that we parse, identified by
  * the calls to defineFunction.


### PR DESCRIPTION
`ParseNode` was the only thing that `parseData.js` was exporting.