### PR TITLE
Test site supports `before=` and `after=` search parameters.

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -30,6 +30,30 @@ function init() {
         macroString += "&" + match[0].substr(1);
     }
 
+    // The `before` search parameter puts normal text before the math.
+    // The `after` search parameter puts normal text after the math.
+    // Example use: testing baseline alignment.
+    if (/(?:^\?|&)(?:before|after)=/.test(window.location.search)) {
+        var mathContainer = math;
+        mathContainer.id = "math-container";
+
+        if ((match = /(?:^\?|&)before=([^&]*)/.exec(window.location.search))) {
+            var child = document.createTextNode(decodeURIComponent(match[1]));
+            mathContainer.appendChild(child);
+            macroString += "&" + match[0].substr(1);
+        }
+
+        math = document.createElement("span");
+        math.id = "math";
+        mathContainer.appendChild(math);
+
+        if ((match = /(?:^\?|&)after=([^&]*)/.exec(window.location.search))) {
+            var child = document.createTextNode(decodeURIComponent(match[1]));
+            mathContainer.appendChild(child);
+            macroString += "&" + match[0].substr(1);
+        }
+    }
+
     reprocess();
 
     function setSearch() {


### PR DESCRIPTION
They add text before/after the math. Example use: testing baseline alignment.

Example usage:
<img width="471" alt="screen shot 2017-07-21 at 8 41 43 am" src="https://user-images.githubusercontent.com/410647/28463827-7a44e672-6df0-11e7-832e-e24f506597b4.png">
