### PR TITLE
Fix Makefile to include images in build files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,14 @@ build/contrib:
 	rm -rf build/contrib/*
 	$(MAKE) -C contrib/auto-render
 
+.PHONY: build/images
+build/images:
+	rm -rf $@
+	mkdir -p build
+	cp -r static/images $@
+
 .PHONY: build/katex
-build/katex: build/katex.js build/katex.min.js build/katex.css build/katex.min.css build/fonts README.md build/contrib
+build/katex: build/katex.js build/katex.min.js build/katex.css build/katex.min.css build/fonts build/images README.md build/contrib
 	mkdir -p build/katex
 	rm -rf build/katex/*
 	cp -r $^ build/katex


### PR DESCRIPTION
Test Plan:
Ran `make` then `find build/katex`. New entries:

```
build/katex/images
build/katex/images/bcancel.svg
build/katex/images/cancel.svg
build/katex/images/doubleleftarrow.svg
build/katex/images/doubleleftrightarrow.svg
build/katex/images/doublerightarrow.svg
build/katex/images/hookleftarrow.svg
build/katex/images/hookrightarrow.svg
build/katex/images/Image-Licensing-and-Technical-Notes.txt
build/katex/images/leftarrow.svg
build/katex/images/leftdoublearrow.svg
build/katex/images/leftharpoon.svg
build/katex/images/leftharpoondown.svg
build/katex/images/leftrightarrow.svg
build/katex/images/leftrightharpoons.svg
build/katex/images/linesegment.svg
build/katex/images/longequal.svg
build/katex/images/mapsto.svg
build/katex/images/overbrace.svg
build/katex/images/overgroup.svg
build/katex/images/rightarrow.svg
build/katex/images/rightharpoon.svg
build/katex/images/rightharpoondown.svg
build/katex/images/rightleftharpoons.svg
build/katex/images/tilde1.svg
build/katex/images/tilde2.svg
build/katex/images/tilde3.svg
build/katex/images/tilde4.svg
build/katex/images/tofrom.svg
build/katex/images/twoheadleftarrow.svg
build/katex/images/twoheadrightarrow.svg
build/katex/images/underbrace.svg
build/katex/images/undergroup.svg
build/katex/images/widehat1.svg
build/katex/images/widehat2.svg
build/katex/images/widehat3.svg
build/katex/images/widehat4.svg
build/katex/images/xcancel.svg
```

Verified `unzip -l build/katex.zip` shows them too. Added this file to `build/katex/test.html` and it renders without error and I see the SVG included via devtools:

```
<!DOCTYPE html>
<link rel="stylesheet" href="katex.css">
<script src="katex.js"></script>
<div id="container"></div>
<script>
katex.render("\\overbrace{xyyyyyyyyyyyyyyyyyyyyyyyyyz}", container);
</script>
```