### PR TITLE
Add latin-1 letters as math symbols

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -671,16 +671,19 @@ for (let i = 0; i < letters.length; i++) {
 // Latin-1 letters
 for (let i = 0x00C0; i <= 0x00D6; i++) {
     const ch = String.fromCharCode(i);
+    defineSymbol(math, main, mathord, ch, ch);
     defineSymbol(text, main, textord, ch, ch);
 }
 
 for (let i = 0x00D8; i <= 0x00F6; i++) {
     const ch = String.fromCharCode(i);
+    defineSymbol(math, main, mathord, ch, ch);
     defineSymbol(text, main, textord, ch, ch);
 }
 
 for (let i = 0x00F8; i <= 0x00FF; i++) {
     const ch = String.fromCharCode(i);
+    defineSymbol(math, main, mathord, ch, ch);
     defineSymbol(text, main, textord, ch, ch);
 }
 

--- a/test/unicode-spec.js
+++ b/test/unicode-spec.js
@@ -70,8 +70,8 @@ describe("unicode", function() {
         expect('\\text{ÀàÇçÉéÏïÖöÛû}').toParse();
     });
 
-    it("should not parse Latin-1 outside \\text{}", function() {
-        expect('ÀàÇçÉéÏïÖöÛû').toNotParse();
+    it("should parse Latin-1 outside \\text{}", function() {
+        expect('ÀàÇçÉéÏïÖöÛû').toParse();
     });
 
     it("should parse Cyrillic inside \\text{}", function() {


### PR DESCRIPTION
Currently katex throws an EOF parse error when receiving an input of latin-1 letters that is not inside a `\text{}` clause. To prevent this the latin-1 letters are added as math-symbols as well. 

![skarmavbild 2017-08-16 kl 09 47 12](https://user-images.githubusercontent.com/9054842/29352910-c6415b1e-8268-11e7-9d77-1321359dbcf0.png)
