### PR TITLE
Pre-commit hook to call make lint

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec make lint

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "object-assign": "^4.1.0",
     "pako": "1.0.4",
     "selenium-webdriver": "^2.48.2",
+    "shared-git-hooks": "^1.2.1",
     "sri-toolbox": "^0.2.0",
     "uglify-js": "~2.7.5"
   },


### PR DESCRIPTION
As discussed in #813. A simple `npm install` will enable this.

Tested on Ubuntu Linux so far. (Do Git hooks work on Windows?)