### PR TITLE
switch pre-commit hook to use pre-commit npm package

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec make lint

--- a/package.json
+++ b/package.json
@@ -36,16 +36,20 @@
     "nomnom": "^1.8.1",
     "object-assign": "^4.1.0",
     "pako": "1.0.4",
+    "pre-commit": "^1.2.2",
     "selenium-webdriver": "^2.48.2",
-    "shared-git-hooks": "^1.2.1",
     "sri-toolbox": "^0.2.0",
     "uglify-js": "~2.7.5"
   },
   "bin": "cli.js",
   "scripts": {
     "test": "make lint test",
+    "lint": "make lint",
     "prepublish": "make NIS= dist"
   },
+  "pre-commit": [
+    "lint"
+  ],
   "dependencies": {
     "match-at": "^0.1.0"
   },


### PR DESCRIPTION
I tested this by doing following:
- edited a .js file in src/ to remove a `;` and ran `git commit -a --amend` and saw the following output
```
pre-commit: 
pre-commit: We've failed to pass the specified git pre-commit hooks as the `lint`
pre-commit: hook returned an exit code (2). If you're feeling adventurous you can
pre-commit: skip the git pre-commit hooks by adding the following flags to your commit:
pre-commit: 
pre-commit:   git commit -n (or --no-verify)
pre-commit: 
pre-commit: This is ill-advised since the commit is broken.
pre-commit: 
```
- then I fixed the lint and re-ran `git commit -a --amend` and saw the following output:
```
./node_modules/.bin/eslint katex.js server.js cli.js src/Lexer.js src/MacroExpander.js src/Options.js src/ParseError.js src/ParseNode.js src/Parser.js src/Settings.js src/Style.js src/buildCommon.js src/buildHTML.js src/buildMathML.js src/buildTree.js src/delimiter.js src/domTree.js src/environments.js src/fontMetrics.js src/fontMetricsData.js src/functions.js src/macros.js src/mathMLTree.js src/parseTree.js src/stretchy.js src/symbols.js src/unicodeRegexes.js src/units.js src/utils.js test/errors-spec.js test/katex-spec.js test/mathml-spec.js test/symgroups.js test/unicode-spec.js contrib/auto-render/auto-render-spec.js contrib/auto-render/auto-render.js contrib/auto-render/splitAtDelimiters.js dockers/Screenshotter/screenshotter.js dockers/texcmp/texcmp.js
[fix_precommit de5b249] switch pre-commit hook to use pre-commit npm package
 Date: Sat Aug 26 18:02:13 2017 -0400
 2 files changed, 5 insertions(+), 3 deletions(-)
 delete mode 100755 hooks/pre-commit
```
- I then ran `npm install` to make sure it would work as well and it did