### PR TITLE
Add better support for ES6 imports and using webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "katex.js",
     "cli.js",
     "src/",
+    "contrib/",
     "dist/"
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.4-pre",
   "description": "Fast math typesetting for the web.",
   "main": "dist/katex.js",
+  "module": "katex.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/Khan/KaTeX.git"


### PR DESCRIPTION
This redirects [webpack](https://webpack.js.org/configuration/resolve/#resolve-mainfields) to use the original `katex.js` file when using ES6 imports.
This makes it possible to consume the `contrib` extensions using webpack.

Closes #828 