### PR TITLE
Update Parser comments to match implementation.

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -43,15 +43,23 @@ import ParseError from "./ParseError";
  * standalone object which can be used as an argument to another function.
  */
 
-/**
- * An initial function (without its arguments), or an argument to a function.
- * The `result` argument should be a ParseNode.
- */
-function ParseFuncOrArgument(result, isFunction, token) {
-    this.result = result;
-    // Is this a function (i.e. is it something defined in functions.js)?
-    this.isFunction = isFunction;
-    this.token = token;
+/** A function name or an argument to a function. */
+class ParseFuncOrArgument {
+    /**
+     * @param {ParseNode|string} result It's a string if `isFunction=true` or if
+     *     `result="$"` for switching into math mode; otherwise, it's a ParseNode
+     *     and `isFunction` must be false. If it's a function, the string should
+     *     be a name defined by defineFunction, e.g. "\\frac".
+     * @param {boolean} isFunction True when this is a function. False when it's a
+     *     function argument or "$" to switch into math mode.
+     * @param {Token} token
+     */
+    constructor(result, isFunction, token) {
+        this.result = result;
+        // Is this a function (i.e. is it something defined in functions.js)?
+        this.isFunction = isFunction;
+        this.token = token;
+    }
 }
 
 class Parser {
@@ -106,7 +114,7 @@ class Parser {
     /**
      * Main parsing function, which parses an entire input.
      *
-     * @return {?Array.<ParseNode>}
+     * @return {Array.<ParseNode>}
      */
     parse() {
         // Try to parse the input
@@ -140,7 +148,7 @@ class Parser {
      *                  should end with, or `null` if something else should end the
      *                  expression.
      *
-     * @return {ParseNode}
+     * @return {Array<ParseNode>}
      */
     parseExpression(breakOnInfix, breakOnTokenText) {
         const body = [];
@@ -179,7 +187,8 @@ class Parser {
      * There can only be one infix operator per group.  If there's more than one
      * then the expression is ambiguous.  This can be resolved by adding {}.
      *
-     * @returns {Array}
+     * @param {Array<ParseNode>} body
+     * @return {Array<ParseNode>}
      */
     handleInfixNodes(body) {
         let overIndex = -1;
@@ -635,7 +644,7 @@ class Parser {
                     if (!this.settings.throwOnError &&
                         this.nextToken.text[0] === "\\") {
                         arg = new ParseFuncOrArgument(
-                            this.handleUnsupportedCmd(this.nextToken.text),
+                            this.handleUnsupportedCmd(),
                             false);
                     } else {
                         throw new ParseError(


### PR DESCRIPTION
I'd been a little confused by some parts of Parser.js, I'd updated some comments for clarity, which I've included in this PR.

I also can't help but wondering whether using a transpiler that supports more compile-time checks (e.g. Google's closure compiler or Microsoft's Typescript) might be worth using to catch some of these mismatches between `@param`/`@return` definitions and actual implementation.