### PR TITLE
Fix #836.

### DIFF
--- a/static/katex.less
+++ b/static/katex.less
@@ -305,7 +305,7 @@
         display: inline-block;
 
         &.negativethinspace {
-            margin-left: -@thinspace;
+            margin-right: -@thinspace;
         }
 
         &.thinspace {
@@ -313,7 +313,7 @@
         }
 
         &.negativemediumspace {
-            margin-left: -@mediumspace;
+            margin-right: -@mediumspace;
         }
 
         &.mediumspace {


### PR DESCRIPTION
margin-right works better for Chrome than margin-left. (margin-left is treated specially given that the surrounding span is display:inline. This seems the minimal fix.)