### PR TITLE
Fix match-at flow errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,5 @@
 [ignore]
 <PROJECT_ROOT>/build
-<PROJECT_ROOT>/node_modules/match-at
 
 [include]
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean-css": "^3.4.23",
     "eslint": "^3.13.0",
     "express": "^4.14.0",
-    "flow-bin": "^0.53.1",
+    "flow-bin": "^0.54.0",
     "glob": "^7.1.1",
     "jest": "^20.0.4",
     "jest-serializer-html": "^4.0.0",
@@ -54,7 +54,7 @@
     "lint"
   ],
   "dependencies": {
-    "match-at": "^0.1.0"
+    "match-at": "^0.1.1"
   },
   "jest": {
     "snapshotSerializers": [


### PR DESCRIPTION
Upgrade match-at and flow versions to resolve the match-at flow
errors, allowing us to remove match-at from the .flowconfig ignore

Test plan:

run `jest` and get the following output:

    PASS  test/unicode-spec.js
    PASS  test/errors-spec.js
    PASS  test/mathml-spec.js
    PASS  test/katex-spec.js (5.104s)

run `flow` and get:

    No errors!