### PR TITLE
Fix small type error in defineFunctions.

### DIFF
--- a/src/defineFunction.js
+++ b/src/defineFunction.js
@@ -4,6 +4,7 @@ import {groupTypes as htmlGroupTypes} from "./buildHTML";
 import {groupTypes as mathmlGroupTypes} from "./buildMathML";
 
 import type Options from "./Options";
+import type {ArgType} from "./types" ;
 
 type FunctionSpec<T> = {
     // Unique string to differentiate parse nodes.
@@ -20,15 +21,8 @@ type FunctionSpec<T> = {
 
         // An array corresponding to each argument of the function, giving the
         // type of argument that should be parsed. Its length should be equal
-        // to `numArgs + numOptionalArgs`. Valid types:
-        //   - "size": A size-like thing, such as "1em" or "5ex"
-        //   - "color": An html color, like "#abc" or "blue"
-        //   - "original": The same type as the environment that the
-        //                 function being parsed is in (e.g. used for the
-        //                 bodies of functions like \textcolor where the
-        //                 first argument is special and the second
-        //                 argument is parsed normally)
-        argTypes?: "color" | "size" | "original",
+        // to `numArgs + numOptionalArgs`.
+        argTypes?: ArgType[],
 
         // The greediness of the function to use ungrouped arguments.
         //

--- a/src/types.js
+++ b/src/types.js
@@ -7,3 +7,12 @@
 
 export type Mode = "math" | "text";
 
+// LaTeX argument type.
+//   - "size": A size-like thing, such as "1em" or "5ex"
+//   - "color": An html color, like "#abc" or "blue"
+//   - "original": The same type as the environment that the
+//                 function being parsed is in (e.g. used for the
+//                 bodies of functions like \textcolor where the
+//                 first argument is special and the second
+//                 argument is parsed normally)
+export type ArgType = "color" | "size" | "original";


### PR DESCRIPTION
Fixes a type error in `defineFunctions.js`. The error becomes more apparent when looking at uses in `functions.js` which is not yet ported to `@flow`. This commit defines a new `ArgType` and moves it to a common `types` file since it's also needed in `environment.js` for #859.

(The commit that adds the common `types` file is identical to the one in [PR 858](https://github.com/Khan/KaTeX/pull/858).)