### PR TITLE
Remove the positions array computed by Parser's parseArguments().

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -226,8 +226,7 @@ class Parser {
                 denomNode = new ParseNode("ordgroup", denomBody, this.mode);
             }
 
-            const value = this.callFunction(
-                funcName, [numerNode, denomNode], null);
+            const value = this.callFunction(funcName, [numerNode, denomNode]);
             return [new ParseNode(value.type, value, this.mode)];
         } else {
             return body;
@@ -468,7 +467,6 @@ class Parser {
                 mode: this.mode,
                 envName: envName,
                 parser: this,
-                positions: args.pop(),
             };
             const result = env.handler(context, args);
             this.expect("\\end", false);
@@ -579,7 +577,7 @@ class Parser {
 
                 const args = this.parseArguments(func, funcData);
                 const token = baseGroup.token;
-                const result = this.callFunction(func, args, args.pop(), token);
+                const result = this.callFunction(func, args, token);
                 return new ParseNode(result.type, result, this.mode);
             } else {
                 return baseGroup.result;
@@ -592,12 +590,11 @@ class Parser {
     /**
      * Call a function handler with a suitable context and arguments.
      */
-    callFunction(name, args, positions, token) {
+    callFunction(name, args, token) {
         const context = {
             funcName: name,
             parser: this,
-            positions: positions,
-            token: token,
+            token,
         };
         return functions[name].handler(context, args);
     }
@@ -607,16 +604,15 @@ class Parser {
      *
      * @param {string} func  "\name" or "\begin{name}"
      * @param {{numArgs:number,numOptionalArgs:number|undefined}} funcData
-     * @return the array of arguments, with the list of positions as last element
+     * @return the array of arguments
      */
     parseArguments(func, funcData) {
         const totalArgs = funcData.numArgs + funcData.numOptionalArgs;
         if (totalArgs === 0) {
-            return [[this.pos]];
+            return [];
         }
 
         const baseGreediness = funcData.greediness;
-        const positions = [this.pos];
         const args = [];
 
         for (let i = 0; i < totalArgs; i++) {
@@ -631,7 +627,6 @@ class Parser {
                 }
                 if (!arg) {
                     args.push(null);
-                    positions.push(this.pos);
                     continue;
                 }
             } else {
@@ -667,10 +662,7 @@ class Parser {
                 argNode = arg.result;
             }
             args.push(argNode);
-            positions.push(this.pos);
         }
-
-        args.push(positions);
 
         return args;
     }

--- a/src/defineFunction.js
+++ b/src/defineFunction.js
@@ -71,8 +71,6 @@ type FunctionSpec<T> = {
     //   - funcName: the text (i.e. name) of the function, including \
     //   - parser: the parser object
     //   - lexer: the lexer object
-    //   - positions: the positions in the overall string of the function
-    //               and the arguments.
     // The latter three should only be used to produce error messages.
     //
     // The function should return an object with the following keys:

--- a/src/environments.js
+++ b/src/environments.js
@@ -10,27 +10,19 @@ import type {ArgType, Mode, StyleStr} from "./types";
  *  - mode: current parsing mode.
  *  - envName: the name of the environment, one of the listed names.
  *  - parser: the parser object.
- *  - positions: the positions associated with these arguments from args.
  */
 type EnvContext = {
     mode: Mode,
     envName: string,
     parser: Parser,
-    positions: number[],
 };
-
-/**
- * List of ParseNodes followed by an array of positions.
- * Returned by `Parser`'s `parseArguments`.
- */
-type ParseResult = (ParseNode | number[])[] | ParseNode;
 
 /**
  * The handler function receives two arguments
  *  - context: information and references provided by the parser
  *  - args: an array of arguments passed to \begin{name}
  */
-type EnvHandler = (context: EnvContext, args: ParseNode[]) => ParseResult;
+type EnvHandler = (context: EnvContext, args: ParseNode[]) => ParseNode;
 
 /**
  *  - numArgs: (default 0) The number of arguments after the \begin{name} function.
@@ -86,7 +78,7 @@ function parseArray(
     parser: Parser,
     result: ArrayEnvNodeData,
     style: StyleStr,
-) {
+): ParseNode {
     let row = [];
     const body = [row];
     const rowGaps = [];
@@ -147,7 +139,7 @@ function defineEnvironment(
 
 // Decides on a style for cells in an array according to whether the given
 // environment name starts with the letter 'd'.
-function dCellStyle(envName) {
+function dCellStyle(envName): StyleStr {
     if (envName.substr(0, 1) === "d") {
         return "display";
     } else {


### PR DESCRIPTION
This array is computed incorrectly (it's always an array of undefineds) and it's not used anywhere. See #863 for details.