### PR TITLE
Support \And

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -151,6 +151,7 @@ defineSymbol(math, main, bin, "\u2219", "\\bullet");
 defineSymbol(math, main, bin, "\u2021", "\\ddagger");
 defineSymbol(math, main, bin, "\u2240", "\\wr");
 defineSymbol(math, main, bin, "\u2a3f", "\\amalg");
+defineSymbol(math, main, bin, "\u0026", "\\And");  // from amsmath
 
 // Arrow Symbols
 defineSymbol(math, main, rel, "\u27f5", "\\longleftarrow");


### PR DESCRIPTION
& as a bin atom, per AMS.

Screenshot:
![and](https://user-images.githubusercontent.com/16403058/30408783-dbd12d66-98b5-11e7-829f-af5fa33174ad.PNG)
