### PR TITLE
Add support for comments, fixes #20

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,9 +8,11 @@
         <link href="main.css" rel="stylesheet" type="text/css">
     </head>
     <body>
-        <input type="text"
-               value="(\left( x \right) \left( x^2 \right) \left( \frac{a}{b} \right) \left( \frac{a^2}{b} \right) \left( \dfrac{a}{b} \right) \left( \dfrac{a^2}{b} \right)"
-               id="input" />
+        <textarea id="input" rows="5">
+\left( x \right) \left( x^2 \right) % comment
+\left( \frac{a}{b} \right) \left( \frac{a^2}{b} \right)
+\left( \dfrac{a}{b} \right) \left( \dfrac{a^2}{b} \right)
+        </textarea>
         <div id="math"></div>
         <input id="permalink" type="button" value="permalink">
         <script src="main.js" type="text/javascript"></script>

--- a/static/main.css
+++ b/static/main.css
@@ -1,6 +1,10 @@
 body {
     margin: 0px;
     padding: 0px;
+    font-size: 24px;
+}
+
+#math {
     font-size: 72px;
 }
 

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1482,6 +1482,35 @@ describe("A font parser", function() {
     });
 });
 
+describe("A comment parser", function() {
+    it("should parse comments at the end of a line", () => {
+        expect("a^2 + b^2 = c^2 % Pythagoras' Theorem\n").toParse();
+    });
+
+    it("should parse comments at the start of a line", () => {
+        expect("% comment\n").toParse();
+    });
+
+    it("should parse multiple lines of comments in a row", () => {
+        expect("% comment 1\n% comment 2\n").toParse();
+    });
+
+    it("should not parse a comment that isn't followed by a newline", () => {
+        expect("x%y").toNotParse();
+    });
+
+    it("should not produce or consume space", () => {
+        expect("\text{hello% comment 1\nworld}")
+            .toParseLike("\text{helloworld}");
+        expect("\text{hello% comment\n\nworld}")
+            .toParseLike("\text{hello world}");
+    });
+
+    it("should not include comments in the output", () => {
+        expect("5 % comment\n").toParseLike("5");
+    });
+});
+
 describe("An HTML font tree-builder", function() {
     it("should render \\mathbb{R} with the correct font", function() {
         const markup = katex.renderToString("\\mathbb{R}");


### PR DESCRIPTION
As part of this PR, I also updated the local test page to use a `<textarea>` so that you can enter newlines.

<img width="1072" alt="screen shot 2017-09-15 at 12 32 45 am" src="https://user-images.githubusercontent.com/1044413/30466959-576bbec4-99af-11e7-8c05-6b91168a6461.png">
