### PR TITLE
Parser: Separate mandatory and optional arguments in parseArguments

### DIFF
--- a/src/defineEnvironment.js
+++ b/src/defineEnvironment.js
@@ -21,11 +21,15 @@ type EnvContext = {|
 |};
 
 /**
- * The handler function receives two arguments
  *  - context: information and references provided by the parser
  *  - args: an array of arguments passed to \begin{name}
+ *  - optArgs: an array of optional arguments passed to \begin{name}
  */
-type EnvHandler = (context: EnvContext, args: ParseNode[]) => ParseNode;
+type EnvHandler = (
+    context: EnvContext,
+    args: ParseNode[],
+    optArgs: (?ParseNode)[],
+) => ParseNode;
 
 /**
  *  - numArgs: (default 0) The number of arguments after the \begin{name} function.

--- a/src/defineFunction.js
+++ b/src/defineFunction.js
@@ -16,13 +16,11 @@ export type FunctionContext = {|
 |};
 
 // TODO: Enumerate all allowed output types.
-
-// TODO: The real type of `args` is `(?ParseNode)[]`, but doing that breaks
-//       compilation since some of these arguments are passed to `ordargument`
-//       below which requires a non-nullable argument.
-//       Separate optional (nullable) `args` from mandatory (non-nullable) args
-//       for better type safety and correct the type here.
-export type FunctionHandler = (context: FunctionContext, args: ParseNode[]) => *;
+export type FunctionHandler = (
+    context: FunctionContext,
+    args: ParseNode[],
+    optArgs: (?ParseNode)[],
+) => *;
 
 export type FunctionPropSpec = {
     // The number of arguments the function takes.
@@ -30,7 +28,8 @@ export type FunctionPropSpec = {
 
     // An array corresponding to each argument of the function, giving the
     // type of argument that should be parsed. Its length should be equal
-    // to `numArgs + numOptionalArgs`.
+    // to `numOptionalArgs + numArgs`, and types for optional arguments
+    // should appear before types for mandatory arguments.
     argTypes?: ArgType[],
 
     // The greediness of the function to use ungrouped arguments.

--- a/src/functions.js
+++ b/src/functions.js
@@ -30,9 +30,9 @@ const defineFunction = function(
 defineFunction(["\\sqrt"], {
     numArgs: 1,
     numOptionalArgs: 1,
-}, function(context, args) {
-    const index = args[0];
-    const body = args[1];
+}, function(context, args, optArgs) {
+    const index = optArgs[0];
+    const body = args[0];
     return {
         type: "sqrt",
         body: body,
@@ -151,10 +151,10 @@ defineFunction(["\\rule"], {
     numArgs: 2,
     numOptionalArgs: 1,
     argTypes: ["size", "size", "size"],
-}, function(context, args) {
-    const shift = args[0];
-    const width = args[1];
-    const height = args[2];
+}, function(context, args, optArgs) {
+    const shift = optArgs[0];
+    const width = args[0];
+    const height = args[1];
     return {
         type: "rule",
         shift: shift && shift.value,
@@ -443,10 +443,10 @@ defineFunction(["\\smash"], {
     numArgs: 1,
     numOptionalArgs: 1,
     allowedInText: true,
-}, function(context, args) {
+}, function(context, args, optArgs) {
     let smashHeight = false;
     let smashDepth = false;
-    const tbArg = args[0];
+    const tbArg = optArgs[0];
     if (tbArg) {
         // Optional [tb] argument is engaged.
         // ref: amsmath: \renewcommand{\smash}[1][tb]{%
@@ -469,7 +469,7 @@ defineFunction(["\\smash"], {
         smashDepth = true;
     }
 
-    const body = args[1];
+    const body = args[0];
     return {
         type: "smash",
         body: body,
@@ -616,9 +616,9 @@ defineFunction([
 ], {
     numArgs: 1,
     numOptionalArgs: 1,
-}, function(context, args) {
-    const below = args[0];
-    const body = args[1];
+}, function(context, args, optArgs) {
+    const below = optArgs[0];
+    const body = args[0];
     return {
         type: "xArrow",   // x for extensible
         label: context.funcName,
@@ -670,8 +670,8 @@ defineFunction(["\\\\", "\\cr"], {
     numArgs: 0,
     numOptionalArgs: 1,
     argTypes: ["size"],
-}, function(context, args) {
-    const size = args[0];
+}, function(context, args, optArgs) {
+    const size = optArgs[0];
     return {
         type: "cr",
         size: size,


### PR DESCRIPTION
This is for improved type strictness per one of the TODOs toward #892.

This overlaps in a minor way with [PR 901](https://github.com/Khan/KaTeX/pull/901), but since I don't know whether the former would require any discussion, I kept this PR independent.
It does require manual merging/rebasing (automatic doesn't work), but it's trivial.