### PR TITLE
ensure that build/ exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,15 +41,19 @@ lint: $(NIS)
 	$(NPM) run lint
 
 build/katex.js: katex.js $(wildcard src/*.js) $(NIS)
+	mkdir -p build
 	$(BROWSERIFY) -t [ babelify ] $< --standalone katex > $@
 
 build/katex.min.js: build/katex.js
+	mkdir -p build
 	$(UGLIFYJS) < $< > $@
 
 build/katex.css: static/katex.less $(wildcard static/*.less) $(NIS)
+	mkdir -p build
 	./node_modules/.bin/lessc $< $@
 
 build/katex.min.css: build/katex.css
+	mkdir -p build
 	$(CLEANCSS) -o $@ $<
 
 .PHONY: build/fonts


### PR DESCRIPTION
release.sh runs `git clean -fdx build dist` before `make setup dist` and so the `build` folder isn't there when the `build/katex.js`, `build/katex.min.js:`, etc. build targets try to get made.  I had considered adding a line `mkdir -p build` in release.sh, but the build targets should be buildable without having to run release.sh and the `build` folder doesn't exist on checkout so that's why I fixed things the way I did.