### PR TITLE
Append ApplyFunction to math functions

### DIFF
--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -8,6 +8,7 @@
 
 import buildCommon from "./buildCommon";
 import fontMetrics from "./fontMetrics";
+import domTree from "./domTree";
 import mathMLTree from "./mathMLTree";
 import ParseError from "./ParseError";
 import Style from "./Style";
@@ -362,8 +363,12 @@ groupTypes.op = function(group, options) {
         node = new mathMLTree.MathNode(
             "mi", [new mathMLTree.TextNode(group.value.body.slice(1))]);
 
-        // TODO(ron): Append an <mo>&ApplyFunction;</mo> as in \operatorname
-        // ref: https://www.w3.org/TR/REC-MathML/chap3_2.html#sec3.2.2
+        // Append an <mo>&ApplyFunction;</mo>.
+        // ref: https://www.w3.org/TR/REC-MathML/chap3_2.html#sec3.2.4
+        const operator = new mathMLTree.MathNode("mo",
+            [makeText("&ApplyFunction;", "text")]);
+
+        return new domTree.documentFragment([node, operator]);
     }
 
     return node;

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -366,7 +366,7 @@ groupTypes.op = function(group, options) {
         // Append an <mo>&ApplyFunction;</mo>.
         // ref: https://www.w3.org/TR/REC-MathML/chap3_2.html#sec3.2.4
         const operator = new mathMLTree.MathNode("mo",
-            [makeText("&ApplyFunction;", "text")]);
+            [makeText("\u2061", "text")]);
 
         return new domTree.documentFragment([node, operator]);
     }

--- a/src/functions/operators.js
+++ b/src/functions/operators.js
@@ -69,7 +69,7 @@ defineFunction({
         identifier.setAttribute("mathvariant", "normal");
 
         const operator = new mathMLTree.MathNode("mo",
-            [mml.makeText("&ApplyFunction;", "text")]);
+            [mml.makeText("\u2061", "text")]);
 
         return new domTree.documentFragment([identifier, operator]);
     },

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -27,6 +27,9 @@ exports[`A MathML builder should generate the right types of nodes 1`] = `
       <mi>
         sin
       </mi>
+      <mo>
+        &amp;ApplyFunction;
+      </mo>
       <mrow>
         <mi>
           x

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -28,7 +28,7 @@ exports[`A MathML builder should generate the right types of nodes 1`] = `
         sin
       </mi>
       <mo>
-        &amp;ApplyFunction;
+        ⁡
       </mo>
       <mrow>
         <mi>


### PR DESCRIPTION
Append a `<mo>&ApplyFunction;</mo>` to the MathML of math functions such as `\sin` or `\tan`.

Ref:  https://www.w3.org/TR/REC-MathML/chap3_2.html#sec3.2.4