### PR TITLE
Simplify get() now that we don't need it to ignorespaces

### DIFF
--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -29,7 +29,7 @@ export default class MacroExpander implements MacroContextInterface {
      */
     future(): Token {
         if (this.stack.length === 0) {
-            this.stack.push(this.lexer.lex());
+            this.pushToken(this.lexer.lex());
         }
         return this.stack[this.stack.length - 1];
     }
@@ -86,7 +86,7 @@ export default class MacroExpander implements MacroContextInterface {
         }
         if (!(isMacro && this.macros.hasOwnProperty(name))) {
             // Fully expanded
-            this.stack.push(topToken);
+            this.pushToken(topToken);
             return topToken;
         }
         const {tokens, numArgs} = this._getExpansion(name);
@@ -224,17 +224,10 @@ export default class MacroExpander implements MacroContextInterface {
     }
 
     /**
-     * Recursively expand first token, then return first non-expandable token.
-     * Equivalent to expandNextToken().
+     * Add a given token to the token stack.  In particular, this get be used
+     * to put back a token returned from one of the other methods.
      */
-    get(): Token {
-        return this.expandNextToken();
-    }
-
-    /**
-     * Undo the effect of the preceding call to the get method.
-     */
-    unget(token: Token) {
+    pushToken(token: Token) {
         this.stack.push(token);
     }
 }

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -140,7 +140,7 @@ export default class Parser {
      * and fetches the one after that as the new look ahead.
      */
     consume() {
-        this.nextToken = this.gullet.get();
+        this.nextToken = this.gullet.expandNextToken();
     }
 
     /**

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -145,13 +145,9 @@ export default class Parser {
 
     /**
      * Switches between "text" and "math" modes.
-     * This used to reconsume nextToken in the new mode because whitespace
-     * handling differed between the two nodes; now it just updates this.mode.
      */
     switchMode(newMode) {
-        //this.gullet.unget(this.nextToken);
         this.mode = newMode;
-        //this.consume();
     }
 
     /**

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -140,17 +140,18 @@ export default class Parser {
      * and fetches the one after that as the new look ahead.
      */
     consume() {
-        this.nextToken = this.gullet.get(false);
+        this.nextToken = this.gullet.get();
     }
 
     /**
-     * Switches between "text" and "math" modes, reconsuming nextToken
-     * in case it would be read differently in the new mode.
+     * Switches between "text" and "math" modes.
+     * This used to reconsume nextToken in the new mode because whitespace
+     * handling differed between the two nodes; now it just updates this.mode.
      */
     switchMode(newMode) {
-        this.gullet.unget(this.nextToken);
+        //this.gullet.unget(this.nextToken);
         this.mode = newMode;
-        this.consume();
+        //this.consume();
     }
 
     /**


### PR DESCRIPTION
Continuation of #912 (forgot to do this change there before merging).

Open question: Should we keep the `get()` alias for `expandNextToken()`, or just use the latter?  `unget()` seems like a useful thing to keep (though it's no longer used), but we could also rename it (e.g. `pushToken`).