### PR TITLE
Prevent disappearing fraction lines.

### DIFF
--- a/static/katex.less
+++ b/static/katex.less
@@ -313,7 +313,7 @@
 
     // Modify min-height for retina displays. Don't force two screen pixels.
     @media screen and (-webkit-min-device-pixel-ratio: 2.0),
-        screen and (min-resolution: 2dppx) {
+        screen and (min-resolution: 192dpi) {
         .mfrac .frac-line,
         .overline .overline-line,
         .underline .underline-line {

--- a/static/katex.less
+++ b/static/katex.less
@@ -301,6 +301,26 @@
         }
     }
 
+    // Set a min-height for some horizontal lines so their display
+    // will show at least one screen pixel.
+    @media screen {
+        .mfrac .frac-line,
+        .overline .overline-line,
+        .underline .underline-line {
+            min-height: 1px;
+        }
+    }
+
+    // Modify min-height for retina displays. Don't force two screen pixels.
+    @media screen and (-webkit-min-device-pixel-ratio: 2.0),
+        screen and (min-resolution: 2dppx) {
+        .mfrac .frac-line,
+        .overline .overline-line,
+        .underline .underline-line {
+            min-height: 0.5px;
+        }
+    }
+
     .mspace {
         display: inline-block;
 


### PR DESCRIPTION
Set a CSS min-height that will ensure that fraction lines will display at least one screen pixel.

Addresses issues #824 and #916.