### PR TITLE
Change \undertilde to \utilde

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -593,7 +593,7 @@ defineFunction([
 // Stretchy accents under the body
 defineFunction([
     "\\underleftarrow", "\\underrightarrow", "\\underleftrightarrow",
-    "\\undergroup", "\\underlinesegment", "\\undertilde",
+    "\\undergroup", "\\underlinesegment", "\\utilde",
 ], {
     numArgs: 1,
 }, function(context, args) {

--- a/src/stretchy.js
+++ b/src/stretchy.js
@@ -12,7 +12,7 @@ import utils from "./utils";
 const stretchyCodePoint = {
     widehat: "^",
     widetilde: "~",
-    undertilde: "~",
+    utilde: "~",
     overleftarrow: "\u2190",
     underleftarrow: "\u2190",
     xleftarrow: "\u2190",
@@ -161,7 +161,7 @@ const svgSpan = function(group, options) {
     let svgNode;
     let span;
 
-    if (utils.contains(["widehat", "widetilde", "undertilde"], label)) {
+    if (utils.contains(["widehat", "widetilde", "utilde"], label)) {
         // There are four SVG images available for each function.
         // Choose a taller image when there are more characters.
         const numChars = groupLength(group.value.base);


### PR DESCRIPTION
In PR #670, I made an error. The function that should have been `\utilde` I named instead `\undertilde`.

There is an `\undertilde` from the `wsuipa` package, but it is a text-mode non-stretchy function. The proper command name is `\utilde`, a math-mode, stretchy function from packge `undertilde`.

This PR fixes my error.