### PR TITLE
Output port number of server, and lint fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "bin": "cli.js",
   "scripts": {
-    "lint": "eslint katex.js server.js cli.js src test contrib dockers && stylelint static/fonts.less static/katex.less",
+    "lint": "eslint katex.js server.js cli.js webpack.config.js webpackDevServer.js src test contrib dockers && stylelint static/fonts.less static/katex.less",
     "flow": "flow",
     "jest": "jest",
     "coverage": "jest --coverage",

--- a/webpackDevServer.js
+++ b/webpackDevServer.js
@@ -1,3 +1,5 @@
+/* eslint no-console:0 */
+
 const WebpackDevServer = require("webpack-dev-server");
 const webpack = require("webpack");
 const webpackConfig = require("./webpack.config.js");
@@ -10,3 +12,4 @@ const compiler = webpack(webpackConfig.compilerConfig);
 const server = new WebpackDevServer(compiler, webpackConfig.devServerConfig);
 
 server.listen(PORT);
+console.log(`Serving on http://localhost:${PORT}/ ...`);


### PR DESCRIPTION
The old `server.js` printed out the URL of the test server.  This small PR adds the same feature to the new `webpackDevServer.js`.

Also, I noticed that `webpackDevServer.js` and `webpack.config.js` were not being linted.  Now they are.