### PR TITLE
Fix node_modules exclusion in webpack server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ const commonConfig = {
             {
                 test: /\.js$/,
                 use: 'babel-loader',
-                exclude: /node_modules\//,
+                exclude: /\bnode_modules\b/,
             },
         ],
     },


### PR DESCRIPTION
On a new installation, I started getting this error:

```
Uncaught TypeError: $export is not a function
```

According to [this StackOverflow discussion](https://stackoverflow.com/questions/36313885/babel-6-transform-runtime-export-is-not-a-function), the slash at the end of the `exclude` configuration is apparently the source.  I don't understand why, but changing as in this tiny PR works well for me.  (The `\b`'s aren't necessary, but feel more appropriate.)