### PR TITLE
Fix frac-line via border-image

### DIFF
--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -281,7 +281,7 @@ const makeLineSpan = function(
 ) {
     // Fill the entire span instead of just a border. That way, the min-height
     // value in katex.less will ensure that at least one screen pixel displays.
-    const line = stretchy.ruleSpan(className, options);
+    const line = makeSpan([className], [], options);
     line.height = options.fontMetrics().defaultRuleThickness;
     line.style.height = line.height + "em";
     line.maxFontSize = 1.0;

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -9,7 +9,6 @@ import domTree from "./domTree";
 import fontMetrics from "./fontMetrics";
 import symbols from "./symbols";
 import utils from "./utils";
-import stretchy from "./stretchy";
 
 import type Options from "./Options";
 import type ParseNode from "./ParseNode";

--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -6,7 +6,6 @@ import ParseError from "../ParseError";
 import ParseNode from "../ParseNode";
 import {calculateSize} from "../units";
 import utils from "../utils";
-import stretchy from "../stretchy";
 
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";

--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -199,8 +199,8 @@ const htmlBuilder = function(group, options) {
             }
 
             if (colDescr.separator === "|") {
-                const separator = stretchy.ruleSpan("vertical-separator",
-                    options);
+                const separator = buildCommon.makeSpan(["vertical-separator"],
+                    []);
                 separator.style.height = totalHeight + "em";
                 separator.style.verticalAlign =
                     -(totalHeight - offset) + "em";

--- a/src/stretchy.js
+++ b/src/stretchy.js
@@ -326,21 +326,8 @@ const encloseSpan = function(
     return img;
 };
 
-const ruleSpan = function(className: string, options: Options): domTree.span {
-    // Get a big square image. The parent span will hide the overflow.
-    const pathNode = new domTree.pathNode('bigRule');
-    const svg =  new domTree.svgNode([pathNode], {
-        "width": "400em",
-        "height": "400em",
-        "viewBox": "0 0 400000 400000",
-        "preserveAspectRatio": "xMinYMin slice",
-    });
-    return buildCommon.makeSpan([className, "hide-tail"], [svg], options);
-};
-
 export default {
     encloseSpan,
     mathMLnode,
-    ruleSpan,
     svgSpan,
 };

--- a/src/svgGeometry.js
+++ b/src/svgGeometry.js
@@ -5,10 +5,6 @@
  */
 
 const path: {[string]: string} = {
-    // bigRule provides a big square image for frac-lines, etc.
-    // The actual rendered rule is smaller, controlled by overflow:hidden.
-    bigRule: 'M0 0 h400000 v400000 h-400000z M0 0 h400000 v400000 h-400000z',
-
     // sqrtMain path geometry is from glyph U221A in the font KaTeX Main
     sqrtMain: `M95 622c-2.667 0-7.167-2.667-13.5
 -8S72 604 72 600c0-2 .333-3.333 1-4 1.333-2.667 23.833-20.667 67.5-54s

--- a/static/katex.less
+++ b/static/katex.less
@@ -298,6 +298,10 @@
         .frac-line {
             display: inline-block;
             width: 100%;
+            box-sizing: border-box;
+            border-style: solid;
+            border-width: 0px;
+            border-image: linear-gradient(currentColor, currentColor) 0 fill stretch;
         }
     }
 
@@ -432,6 +436,10 @@
     .underline .underline-line {
         display: inline-block;
         width: 100%;
+        box-sizing: border-box;
+        border-style: solid;
+        border-width: 0px;
+        border-image: linear-gradient(currentColor, currentColor) 0 fill stretch;
     }
 
     .sqrt {
@@ -548,6 +556,11 @@
     .mtable {
         .vertical-separator {
             display: inline-block;
+            box-sizing: border-box;
+            border-style: solid;
+            border-width: 0px;
+            border-image: linear-gradient(currentColor, currentColor) 0 fill stretch;
+
             margin: 0 -0.025em;
             width: 0.05em;
 


### PR DESCRIPTION
Use a border-image instead of a border to render a frac-line. That way, a `min-height` will apply to the line.