### PR TITLE
Make a more working example in autorender README

### DIFF
--- a/contrib/auto-render/README.md
+++ b/contrib/auto-render/README.md
@@ -6,10 +6,13 @@ renders the math in place.
 
 ### Usage
 
-This extension isn't part of KaTeX proper, so the script should be separately
-included in the page:
+This extension isn't part of KaTeX proper, so the script needs to be included
+(via a `<script>` tag) in the page along with KaTeX itself.  For example,
+using a CDN:
 
 ```html
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha2/katex.min.css" integrity="sha384-exe4Ak6B0EoJI0ogGxjJ8rn+RN3ftPnEQrGwX59KTCl5ybGzvHGKjhPKk/KC3abb" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha2/katex.min.js" integrity="sha384-OMvkZ24ANLwviZR2lVq8ujbE/bUO8IR1FdBrKLQBI14Gq5Xp/lksIccGkmKL8m+h" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.9.0-alpha2/contrib/auto-render.min.js" integrity="sha384-cXpztMJlr2xFXyDSIfRWYSMVCXZ9HeGXvzyKTYrn03rsMAlOtIQVzjty5ULbaP8L" crossorigin="anonymous"></script>
 ```
 


### PR DESCRIPTION
This is an attempt to flesh out the required <head> tags needed to make a full working example of autorender, including KaTeX itself, to help people get started with KaTeX. The goal is to fix #1049.