### PR TITLE
add perf tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,6 +1375,16 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4",
+        "platform": "1.3.4"
+      }
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -6292,7 +6302,7 @@
         "istanbul-lib-report": "1.1.2",
         "istanbul-lib-source-maps": "1.2.2",
         "istanbul-reports": "1.1.3",
-        "js-yaml": "3.8.4",
+        "js-yaml": "3.10.0",
         "mkdirp": "0.5.1",
         "once": "1.4.0"
       },
@@ -7326,13 +7336,21 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
-        "esprima": "3.1.3"
+        "esprima": "4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        }
       }
     },
     "jsbn": {
@@ -8968,6 +8986,12 @@
       "requires": {
         "find-up": "2.1.0"
       }
+    },
+    "platform": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
+      "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
+      "dev": true
     },
     "pluralize": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-flow": "^6.23.0",
     "babel-register": "^6.26.0",
+    "benchmark": "^2.1.4",
     "check-dependencies": "^1.1.0",
     "css-loader": "^0.28.8",
     "eslint": "^4.14.0",
@@ -33,7 +34,7 @@
     "flow-bin": "^0.62.0",
     "jest": "^22.0.4",
     "jest-serializer-html": "^4.0.1",
-    "js-yaml": "^3.3.1",
+    "js-yaml": "^3.10.0",
     "json-stable-stringify": "^1.0.1",
     "jspngopt": "^0.2.0",
     "less": "~2.7.1",
@@ -66,6 +67,7 @@
     "start": "check-dependencies && webpack-dev-server --open --config webpack.dev.js",
     "build": "check-dependencies && rimraf build/* && webpack",
     "watch": "npm run build -- --watch",
+    "perf-test": "check-dependencies && NODE_ENV=test node test/perf-test.js",
     "prepublishOnly": "make NIS= dist"
   },
   "pre-commit": [

--- a/test/perf-test.js
+++ b/test/perf-test.js
@@ -1,0 +1,59 @@
+/* eslint-disable no-console */
+/**
+ * Performance Tests
+ *
+ * This file measures the performance of renderToString using a number of strings
+ * from ss_data.yaml.
+ *
+ * TODO:
+ * - allow users to specify a different key or keys from ss_data.yaml
+ * - allow users to specify a different string or strings
+ * - provide a way to test the performance against different branches
+ */
+require('babel-register');
+const Benchmark = require('benchmark');
+const yaml = require('js-yaml');
+const fs = require('fs');
+const path = require('path');
+
+const filename = path.resolve(__dirname, 'screenshotter/ss_data.yaml');
+const data = yaml.load(fs.readFileSync(filename, 'utf-8'));
+
+console.log('compiling katex...');
+const katex = require('../katex').default;
+console.log('');
+
+// Benchmark is a performancing testing library.  It allows you to define a
+// suite of tests.  After adding tests to the suite with the .add() method they
+// can be run by calling the .run() method.  See https://benchmarkjs.com.
+const suite = new Benchmark.Suite;
+
+const testsToRun = [
+    "AccentsText",
+    "ArrayMode",
+    "GroupMacros",
+    "MathBb",
+    "SqrtRoot",
+    "StretchyAccent",
+    "Units",
+];
+
+for (const key of testsToRun) {
+    const value = data[key];
+    if (typeof value === "string") {
+        suite.add(key, () => katex.renderToString(value));
+    } else {
+        const options = {
+            macros: value.macros,
+        };
+        suite.add(key, () => katex.renderToString(value.tex, options));
+    }
+}
+
+// Print out the ops/sec for each test
+suite.on('cycle', function(event) {
+    console.log(String(event.target));
+});
+
+const config = {};
+suite.run(config);


### PR DESCRIPTION
Here's the output I get when I run `npm run perf-test`:
```
compiling katex...

AccentsText x 2,416 ops/sec ±4.79% (80 runs sampled)
ArrayMode x 344 ops/sec ±1.35% (85 runs sampled)
GroupMacros x 7,374 ops/sec ±5.01% (82 runs sampled)
MathBb x 1,976 ops/sec ±1.10% (84 runs sampled)
SqrtRoot x 1,424 ops/sec ±0.95% (86 runs sampled)
StretchyAccent x 370 ops/sec ±1.64% (83 runs sampled)
Units x 298 ops/sec ±3.04% (78 runs sampled)
Fastest is GroupMacros
(khan27)kb-no-mbp:KaTeX kevinbarbash$ git st
On branch perf_test
```
This fixes #1053.