### PR TITLE
Add support for \aa, \AA, \lq, \rq, \lbrack, \rbrack

### DIFF
--- a/src/macros.js
+++ b/src/macros.js
@@ -96,11 +96,27 @@ defineMacro("\\TextOrMath", function(context) {
 });
 
 //////////////////////////////////////////////////////////////////////
-// basics
+// Grouping
+// \let\bgroup={ \let\egroup=}
 defineMacro("\\bgroup", "{");
 defineMacro("\\egroup", "}");
 defineMacro("\\begingroup", "{");
 defineMacro("\\endgroup", "}");
+
+// Symbols from latex.ltx:
+// \let\bgroup={ \let\egroup=}
+// \def\lq{`}
+// \def\rq{'}
+// \def\lbrack{[}
+// \def\rbrack{]}
+// \def \aa {\r a}
+// \def \AA {\r A}
+defineMacro("\\lq", "`");
+defineMacro("\\rq", "'");
+defineMacro("\\lbrack", "[");
+defineMacro("\\rbrack", "]");
+defineMacro("\\aa", "\\r a");
+defineMacro("\\AA", "\\r A");
 
 // Unicode double-struck letters
 defineMacro("\u2102", "\\mathbb{C}");

--- a/src/macros.js
+++ b/src/macros.js
@@ -104,7 +104,6 @@ defineMacro("\\begingroup", "{");
 defineMacro("\\endgroup", "}");
 
 // Symbols from latex.ltx:
-// \let\bgroup={ \let\egroup=}
 // \def\lq{`}
 // \def\rq{'}
 // \def\lbrack{[}

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2798,6 +2798,12 @@ describe("Unicode accents", function() {
             "\\'y\\\"y}");
     });
 
+    it("should support \\aa in text mode", function() {
+        expect("\\text{\\aa\\AA}").toParseLike("\\text{\\r a\\r A}");
+        expect("\\aa").toNotParse();
+        expect("\\Aa").toNotParse();
+    });
+
     it("should parse combining characters", function() {
         expect("A\u0301C\u0301").toParseLike("Á\\acute C");
         expect("\\text{A\u0301C\u0301}").toParseLike("\\text{Á\\'C}");


### PR DESCRIPTION
The lack of `\aa` and `\AA` was reported in #1066.  Added these via simple macros, with supporting tests.

Also add `\lq`, `\rq`, `\lbrack`, `\rbrack` as aliases for "\`", `'`, `[`, `]` which were in the same area of latex.ltx.