### PR TITLE
Remove non-portable use of String method .includes

### DIFF
--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -244,7 +244,7 @@ const makeOrd = function(
             const fontData = mathit(value, mode, options, classes);
             fontName = fontData.fontName;
             fontClasses = [fontData.fontClass];
-        } else if (fontFamily.includes("math") || mode === "math") {
+        } else if (fontFamily.indexOf("math") !== -1 || mode === "math") {
             // To support old font functions (i.e. \rm \sf etc.) or math mode.
             fontName = fontMap[fontFamily].fontName;
             fontClasses = [fontFamily];


### PR DESCRIPTION
This is a minimal fix for #1093 which apparently has been introduced with #1009.

Notes:
* I have checked (with `grep`) that there are no other uses of `.includes`.
* A `>= 0` would probably look more natural, but [Mozilla's polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Polyfill) uses `!== -1`, and I just follow their lead.
* No tests included and no countermeasures taken against future incidents like this one. I am not familiar enough with this project yet.