### PR TITLE
Add support for \mathring

### DIFF
--- a/src/functions/accent.js
+++ b/src/functions/accent.js
@@ -174,7 +174,7 @@ const mathmlBuilder = (group, options) => {
 
 const NON_STRETCHY_ACCENT_REGEX = new RegExp([
     "\\acute", "\\grave", "\\ddot", "\\tilde", "\\bar", "\\breve",
-    "\\check", "\\hat", "\\vec", "\\dot",
+    "\\check", "\\hat", "\\vec", "\\dot", "\\mathring",
 ].map(accent => `\\${accent}`).join("|"));
 
 // Accents
@@ -182,7 +182,7 @@ defineFunction({
     type: "accent",
     names: [
         "\\acute", "\\grave", "\\ddot", "\\tilde", "\\bar", "\\breve",
-        "\\check", "\\hat", "\\vec", "\\dot",
+        "\\check", "\\hat", "\\vec", "\\dot", "\\mathring",
         "\\widehat", "\\widetilde", "\\overrightarrow", "\\overleftarrow",
         "\\Overrightarrow", "\\overleftrightarrow", "\\overgroup",
         "\\overlinesegment", "\\overleftharpoon", "\\overrightharpoon",

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -646,6 +646,7 @@ defineSymbol(math, main, accent, "\u02c7", "\\check");
 defineSymbol(math, main, accent, "\u005e", "\\hat");
 defineSymbol(math, main, accent, "\u20d7", "\\vec");
 defineSymbol(math, main, accent, "\u02d9", "\\dot");
+defineSymbol(math, main, accent, "\u02da", "\\mathring");
 defineSymbol(math, main, mathord, "\u0131", "\\imath", true);
 defineSymbol(math, main, mathord, "\u0237", "\\jmath", true);
 defineSymbol(text, main, textord, "\u0131", "\\i", true);

--- a/src/unicodeAccents.js
+++ b/src/unicodeAccents.js
@@ -13,6 +13,6 @@ module.exports = {
     '\u030c': {text: '\\v', math: '\\check'},
     '\u0302': {text: '\\^', math: '\\hat'},
     '\u0307': {text: '\\.', math: '\\dot'},
-    '\u030a': {text: '\\r'},
+    '\u030a': {text: '\\r', math: '\\mathring'},
     '\u030b': {text: '\\H'},
 };


### PR DESCRIPTION
Fix #1124. `\mathring` is the math-mode equivalent to the `\r` accent (thanks to @akalin for pointing it out!).

Support follows from a rather trivial symbol aliasing, plus (for Unicode support) listing it in `unicodeAccents.js`.

Screenshot of
```latex
\mathring A\mathring B\textit{\r A\r B}\text{\r A\r B}
```
shows that skew correction is fine, except somehow for `\textit` (as reported in #1099):
![image](https://user-images.githubusercontent.com/2218736/35654343-a275afce-06ba-11e8-9699-e82b365a9328.png)
