### PR TITLE
Enable trailing functions

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -628,7 +628,7 @@ export default class Parser {
                     arg = newArgument(this.handleUnsupportedCmd(), nextToken);
                 } else if (this.nextToken.text === "EOF") {
                     args.push(new ParseNode("text", {body: [], type: "text",
-                        }, this.mode));
+                    }, this.mode));
                     continue;
                 } else {
                     throw new ParseError(

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -627,7 +627,7 @@ export default class Parser {
                     this.nextToken.text[0] === "\\") {
                     arg = newArgument(this.handleUnsupportedCmd(), nextToken);
                 } else if (this.nextToken.text === "EOF") {
-                    args.push(null);
+                    args.push("");
                     continue;
                 } else {
                     throw new ParseError(

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -626,6 +626,9 @@ export default class Parser {
                 if (!this.settings.throwOnError &&
                     this.nextToken.text[0] === "\\") {
                     arg = newArgument(this.handleUnsupportedCmd(), nextToken);
+                } else if (this.nextToken.text === "EOF") {
+                    args.push(null);
+                    continue;
                 } else {
                     throw new ParseError(
                         "Expected group after '" + func + "'", nextToken);

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -627,7 +627,8 @@ export default class Parser {
                     this.nextToken.text[0] === "\\") {
                     arg = newArgument(this.handleUnsupportedCmd(), nextToken);
                 } else if (this.nextToken.text === "EOF") {
-                    args.push("");
+                    args.push(new ParseNode("text", {body: [], type: "text",
+                        }, this.mode));
                     continue;
                 } else {
                     throw new ParseError(

--- a/test/errors-spec.js
+++ b/test/errors-spec.js
@@ -148,10 +148,6 @@ describe("Parser:", function() {
     });
 
     describe("#parseArguments", function() {
-        it("complains about missing argument at end of input", function() {
-            expect("2\\sqrt").toFailWithParseError(
-                   "Expected group after '\\sqrt' at end of input: 2\\sqrt");
-        });
         it("complains about missing argument at end of group", function() {
             expect("1^{2\\sqrt}").toFailWithParseError(
                    "Expected group after '\\sqrt'" +
@@ -166,10 +162,6 @@ describe("Parser:", function() {
     });
 
     describe("#parseArguments", function() {
-        it("complains about missing argument at end of input", function() {
-            expect("2\\sqrt").toFailWithParseError(
-                   "Expected group after '\\sqrt' at end of input: 2\\sqrt");
-        });
         it("complains about missing argument at end of group", function() {
             expect("1^{2\\sqrt}").toFailWithParseError(
                    "Expected group after '\\sqrt'" +

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -620,7 +620,7 @@ describe("A function parser", function() {
     });
 
     it("should parse 1 argument functions", function() {
-        expect("\\blue x").toParse();
+        expect("\\sqrt x").toParse();
     });
 
     it("should parse 2 argument functions", function() {
@@ -628,13 +628,21 @@ describe("A function parser", function() {
     });
 
     it("should not parse 1 argument functions with no arguments", function() {
-        expect("\\blue").toNotParse();
+        expect("{\\sqrt}").toNotParse();
+    });
+
+    it("should parse 1 argument functions at end of input", function() {
+        expect("\\sqrt").toParse();
     });
 
     it("should not parse 2 argument functions with 0 or 1 arguments", function() {
-        expect("\\frac").toNotParse();
+        expect("{\\frac}").toNotParse();
 
-        expect("\\frac 1").toNotParse();
+        expect("{\\frac 1}").toNotParse();
+    });
+
+    it("should parse trailing 2 argument functions with 1 arg", function() {
+        expect("\\frac 1").toParse();
     });
 
     it("should not parse a function with text right after it", function() {
@@ -1348,14 +1356,17 @@ describe("A begin/end parser", function() {
 
 describe("A sqrt parser", function() {
     const sqrt = "\\sqrt{x}";
-    const missingGroup = "\\sqrt";
 
     it("should parse square roots", function() {
         expect(sqrt).toParse();
     });
 
     it("should error when there is no group", function() {
-        expect(missingGroup).toNotParse();
+        expect("{\\sqrt}").toNotParse();
+    });
+
+    it("should parse when there is no group at EOL", function() {
+        expect("\\sqrt").toParse();
     });
 
     it("should produce sqrts", function() {
@@ -1372,12 +1383,11 @@ describe("A TeX-compliant parser", function() {
 
     it("should fail if there are not enough arguments", function() {
         const missingGroups = [
-            "\\frac{x}",
-            "\\textcolor{#fff}",
-            "\\rule{1em}",
-            "\\llap",
-            "\\bigl",
-            "\\text",
+            "{\\frac{x}}",
+            "{\\textcolor{#fff}}",
+            "{\\rule{1em}}",
+            "{\\bigl}",
+            "{\\text}",
         ];
 
         for (let i = 0; i < missingGroups.length; i++) {
@@ -2123,6 +2133,11 @@ describe("An extensible arrow parser", function() {
         expect("\\xrightarrow{x}^2").toParse();
         expect("\\xrightarrow x").toParse();
         expect("\\xrightarrow[under]{over}").toParse();
+        expect("\\xrightarrow").toParse();  // no args is ok at EOF
+    });
+
+    it("should fail when given no arguments", function() {
+        expect("{\\xrightarrow}").toNotParse();
     });
 
     it("should produce xArrow", function() {
@@ -2145,6 +2160,7 @@ describe("An extensible arrow builder", function() {
         expect("\\xrightarrow{x}_2").toBuild();
         expect("\\xrightarrow{x}_2^2").toBuild();
         expect("\\xrightarrow[under]{over}").toBuild();
+        expect("\\xrightarrow").toBuild();
     });
 
     it("should produce mrell", function() {


### PR DESCRIPTION
In general, TeX functions should not parse if an argument is omitted. So `{\sqrt}` should throw an error. But there seems to be an exception. That is when the function is written at the end of an expression and the parser encounters EOF instead of the argument.

Don’t believe me? Well, here are some examples rendered from http://www.quicklatex.com.

 1.  `\( \sqrt \)` renders as ![sqrt](http://quicklatex.com/cache3/24/ql_ce191a8d635f65f37131dffa71c4e524_l3.png)
 2.  `\( \frac{a}{a} \frac a \)` renders as ![frac](http://quicklatex.com/cache3/75/ql_22bb40fcef04f2662ed35a96afd90575_l3.png)
3.  `\( \xrightarrow \)` renders as ![xrightarrow](http://quicklatex.com/cache3/f1/ql_d0dc49b3b0f7ad58d7d7430bc35cbff1_l3.png)

This PR captures that behavior and edits several parse tests to accommodate the change.

A side benefit will occur at http://utensil-site.github.io/available-in-katex/, where four extensible arrows will flip from red to green.