### PR TITLE
Support Unicode colon equals

### DIFF
--- a/src/macros.js
+++ b/src/macros.js
@@ -400,7 +400,7 @@ defineMacro("\\Colonsim", "\\dblcolon\\mathrel{\\mkern-1.2mu}\\sim");
 // Some Unicode characters are implemented with macros to mathtools functions.
 defineMacro("\u2254", "\\coloneqq");  // :=
 defineMacro("\u2255", "\\eqqcolon");  // =:
-defineMacro("\u2A74", "\\Eqqcolon");  // ::=
+defineMacro("\u2A74", "\\Coloneqq");  // ::=
 
 //////////////////////////////////////////////////////////////////////
 // colonequals.sty

--- a/src/macros.js
+++ b/src/macros.js
@@ -397,6 +397,11 @@ defineMacro("\\colonsim", "\\vcentcolon\\mathrel{\\mkern-1.2mu}\\sim");
 // \providecommand*\Colonsim{\dblcolon\mathrel{\mkern-1.2mu}\sim}
 defineMacro("\\Colonsim", "\\dblcolon\\mathrel{\\mkern-1.2mu}\\sim");
 
+// Some Unicode characters are implemented with macros to mathtools functions.
+defineMacro("\u2254", "\\coloneqq");  // :=
+defineMacro("\u2255", "\\eqqcolon");  // =:
+defineMacro("\u2A74", "\\Eqqcolon");  // ::=
+
 //////////////////////////////////////////////////////////////////////
 // colonequals.sty
 

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2915,7 +2915,7 @@ describe("Unicode", function() {
     });
 
     it("should parse relations", function() {
-        expect("∈∋∝∼∽≂≃≅≈≊≍≎≏≐≑≒≓≖≗≜≡≤≥≦≧≫≬≳≷≺≻≼≽≾≿∴∵∣").toParse();
+        expect("∈∋∝∼∽≂≃≅≈≊≍≎≏≐≑≒≓≖≗≜≡≤≥≦≧≫≬≳≷≺≻≼≽≾≿∴∵∣≔≕⩴").toParse();
     });
 
     it("should parse big operators", function() {


### PR DESCRIPTION
This PR adds support for three Unicode characters: `≔` `≕` `⩴`