### PR TITLE
add .codecov.yml and disable patch coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default: on
+    patch:
+      default: off
+    changes:
+      default: off
+
+comment:
+  layout: "header, reach, diff, flags, files, footer"
+  behavior: default
+  require_changes: no
+  require_base: no
+  require_head: yes


### PR DESCRIPTION
It doesn't make sense to have a target for patch coverage b/c you may be editing a file that has really low coverage to begin with and it shouldn't be your responsibility to bring it up to the target as part of the PR.