### PR TITLE
Fix contenteditable mode

### DIFF
--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -551,12 +551,12 @@ const makeVList = function(params: VListParam, options: Options): domTree.span {
     let rows;
     if (minPos < 0) {
         // We will define depth in an empty span with display: table-cell.
-		// It should render with the height that we define. But Chrome, in
-		// contenteditable mode only, treats that span as if it contains some
-		// text content. And that min-height over-rides our desired height.
-		// So we put another empty span inside the depth strut span.
-		const emptySpan = makeSpan([], []);
-		const depthStrut = makeSpan(["vlist"], [emptySpan]);
+        // It should render with the height that we define. But Chrome, in
+        // contenteditable mode only, treats that span as if it contains some
+        // text content. And that min-height over-rides our desired height.
+        // So we put another empty span inside the depth strut span.
+        const emptySpan = makeSpan([], []);
+        const depthStrut = makeSpan(["vlist"], [emptySpan]);
         depthStrut.style.height = -minPos + "em";
 
         // Safari wants the first row to have inline content; otherwise it

--- a/src/buildCommon.js
+++ b/src/buildCommon.js
@@ -550,7 +550,13 @@ const makeVList = function(params: VListParam, options: Options): domTree.span {
     // A second row is used if necessary to represent the vlist's depth.
     let rows;
     if (minPos < 0) {
-        const depthStrut = makeSpan(["vlist"], []);
+        // We will define depth in an empty span with display: table-cell.
+		// It should render with the height that we define. But Chrome, in
+		// contenteditable mode only, treats that span as if it contains some
+		// text content. And that min-height over-rides our desired height.
+		// So we put another empty span inside the depth strut span.
+		const emptySpan = makeSpan([], []);
+		const depthStrut = makeSpan(["vlist"], [emptySpan]);
         depthStrut.style.height = -minPos + "em";
 
         // Safari wants the first row to have inline content; otherwise it


### PR DESCRIPTION
`makeVList` sets depth with an empty span for which it defines a span height. But Chrome, in `contenteditable` mode only, treats that span as if it contains some text.  The resulting `min-height` can over-ride our desired depth.

So we insert an empty span inside the `depthStrut` span. This fixes issue #1178.

I don't know how to write a test for this. The condition only occurs inside an external `contenteditable` div.