### PR TITLE
Add unicode-fonts as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "submodules/katex-fonts"]
 	path = submodules/katex-fonts
 	url = https://github.com/KaTeX/katex-fonts
+[submodule "submodules/unicode-fonts"]
+	path = submodules/unicode-fonts
+	url = https://github.com/Khan/KaTeX-test-fonts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submodules/katex-fonts"]
 	path = submodules/katex-fonts
 	url = https://github.com/KaTeX/katex-fonts
-[submodule "submodules/unicode-fonts"]
-	path = submodules/unicode-fonts
-	url = https://github.com/Khan/KaTeX-test-fonts.git
+[submodule "submodules/katex-test-fonts"]
+	path = submodules/katex-test-fonts
+	url = https://github.com/KaTeX/katex-test-fonts.git

--- a/dockers/Screenshotter/screenshotter.sh
+++ b/dockers/Screenshotter/screenshotter.sh
@@ -14,18 +14,6 @@ cleanup() {
     container=
 }
 
-SS_DIR=$(dirname "$0")
-TOP_DIR=${SS_DIR}/../..
-FONTS_DIR=${TOP_DIR}/test/screenshotter/unicode-fonts
-if [[ ! -d "${FONTS_DIR}" ]]; then
-    echo "Cloning test fonts repository"
-    git clone https://github.com/Khan/KaTeX-test-fonts "${FONTS_DIR}" \
-        || exit 2
-fi
-pushd "${FONTS_DIR}" || exit 2
-git checkout --detach 99fa66a2da643218754c8236b9f9151cac71ba7c || exit 2
-popd || exit 2
-
 container=
 trap cleanup EXIT
 status=0

--- a/test/screenshotter/test.html
+++ b/test/screenshotter/test.html
@@ -12,11 +12,11 @@
       }
       @font-face {
         font-family: "Mincho";
-        src: url("unicode-fonts/mincho/font_1_honokamin.ttf") format("truetype");
+        src: url("/submodules/unicode-fonts/mincho/font_1_honokamin.ttf") format("truetype");
       }
       @font-face {
         font-family: "Batang";
-        src: url("unicode-fonts/batang/batang.ttf") format("truetype");
+        src: url("/submodules/unicode-fonts/batang/batang.ttf") format("truetype");
       }
       .katex .cjk_fallback {
           font-family: "Mincho",serif;

--- a/test/screenshotter/test.html
+++ b/test/screenshotter/test.html
@@ -12,11 +12,11 @@
       }
       @font-face {
         font-family: "Mincho";
-        src: url("/submodules/unicode-fonts/mincho/font_1_honokamin.ttf") format("truetype");
+        src: url("/submodules/katex-test-fonts/mincho/font_1_honokamin.ttf") format("truetype");
       }
       @font-face {
         font-family: "Batang";
-        src: url("/submodules/unicode-fonts/batang/batang.ttf") format("truetype");
+        src: url("/submodules/katex-test-fonts/batang/batang.ttf") format("truetype");
       }
       .katex .cjk_fallback {
           font-family: "Mincho",serif;


### PR DESCRIPTION
\+ Removed checkout process from screenshotter.sh.

I think it's better to have them as a submodule, since git and GitHub handle it very well and we already have one submodule. Also, it's cross-platform and no extra manual step is needed when running `screenshotter.js` directly.