### PR TITLE
Add \yen support to text mode

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -276,6 +276,7 @@ defineSymbol(math, ams, textord, "\u25a1", "\\Box");
 defineSymbol(math, ams, textord, "\u25ca", "\\Diamond");
 // unicode-math maps U+A5 to \mathyen. We map to AMS function \yen
 defineSymbol(math, ams, textord, "\u00a5", "\\yen", true);
+defineSymbol(text, ams, textord, "\u00a5", "\\yen", true);
 defineSymbol(math, ams, textord, "\u2713", "\\checkmark", true);
 defineSymbol(text, ams, textord, "\u2713", "\\checkmark");
 

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2612,6 +2612,16 @@ describe("The symbol table integrity", function() {
     });
 });
 
+describe("Symbols", function() {
+    it("should support AMS symbols in both text and math mode", function() {
+        // These text+math symbols are from Section 6 of
+        // http://mirrors.ctan.org/fonts/amsfonts/doc/amsfonts.pdf
+        const symbols = "\\yen\\checkmark\\circledR\\maltese";
+        expect(symbols).toBuild();
+        expect(`\\text{${symbols}}`).toBuild();
+    });
+});
+
 describe("A macro expander", function() {
 
     const compareParseTree = function(actual, expected, macros) {


### PR DESCRIPTION
Fix #1204 by adding `\yen` support to text mode.

More generally, I checked all the text+mode symbols supported by [amsfonts](http://mirrors.ctan.org/fonts/amsfonts/doc/amsfonts.pdf) (see Section 6), and found that `\yen` is the only one lacking text-mode support.

Here's a screenshot of the tester confirming support:

![image](https://user-images.githubusercontent.com/2218736/37305489-0158f5cc-260b-11e8-990f-6b768fd777f2.png)
