### PR TITLE
Support \( and fix instant mode switching for $, \(, \text

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -504,12 +504,17 @@ export default class Parser {
                     baseGroup.token);
             }
 
-            const oldMode = this.mode;
+            // Consume the command token after possibly switching to the
+            // mode specified by the function (for instant mode switching),
+            // and then immediately switch back.
             if (funcData.consumeMode) {
+                const oldMode = this.mode;
                 this.switchMode(funcData.consumeMode);
+                this.consume();
+                this.switchMode(oldMode);
+            } else {
+                this.consume();
             }
-            this.consume();  // Consume the command token
-            this.switchMode(oldMode);
             const {args, optArgs} = this.parseArguments(func, funcData);
             const token = baseGroup.token;
             const result = this.callFunction(
@@ -910,8 +915,8 @@ export default class Parser {
         if (functions[text]) {
             // If there exists a function with this name, we return the
             // function and say that it is a function.
-            // The token will be consumed later when parsing the arguments,
-            // after possibly switching modes.
+            // The token will be consumed later in parseGivenFunction
+            // (after possibly switching modes).
             return newFunction(nucleus);
         } else if (/^\\verb[^a-zA-Z]/.test(text)) {
             this.consume();

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -505,15 +505,15 @@ export default class Parser {
             }
 
             const oldMode = this.mode;
-            if (funcData.modeSwitch) {
-                this.switchMode(funcData.modeSwitch);
+            if (funcData.consumeMode) {
+                this.switchMode(funcData.consumeMode);
             }
             this.consume();  // Consume the command token
             this.switchMode(oldMode);
             const {args, optArgs} = this.parseArguments(func, funcData);
             const token = baseGroup.token;
             const result = this.callFunction(
-                func, args, optArgs, token, breakOnTokenText, oldMode);
+                func, args, optArgs, token, breakOnTokenText);
             return new ParseNode(result.type, result, this.mode);
         } else {
             return baseGroup.result;
@@ -529,14 +529,12 @@ export default class Parser {
         optArgs: (?ParseNode)[],
         token?: Token,
         breakOnTokenText?: BreakToken,
-        oldMode?: Mode,
     ): * {
         const context: FunctionContext = {
             funcName: name,
             parser: this,
             token,
             breakOnTokenText,
-            oldMode,
         };
         const func = functions[name];
         if (func && func.handler) {

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -509,6 +509,7 @@ export default class Parser {
                 this.switchMode(funcData.modeSwitch);
             }
             this.consume();  // Consume the command token
+            this.switchMode(oldMode);
             const {args, optArgs} = this.parseArguments(func, funcData);
             const token = baseGroup.token;
             const result = this.callFunction(

--- a/src/defineFunction.js
+++ b/src/defineFunction.js
@@ -14,7 +14,6 @@ export type FunctionContext = {|
     parser: Parser,
     token?: Token,
     breakOnTokenText?: BreakToken,
-    oldMode: ?Mode,
 |};
 
 // TODO: Enumerate all allowed output types.
@@ -72,13 +71,13 @@ export type FunctionPropSpec = {
     // Must be true if the function is an infix operator.
     infix?: boolean,
 
-    // Switch to the specified mode before consuming the command token,
-    // including before parsing the arguments.  This is useful for commands
-    // that switch between math and text mode.  `null` does not switch,
-    // while `"text"` or `"math"` will switch to the specified mode.
-    // It's the function handler's responsibility to switch back to the
-    // old mode, which is given by the oldMode field in the context object.
-    modeSwitch?: ?Mode,
+    // Switch to the specified mode while consuming the command token.
+    // This is useful for commands that switch between math and text mode,
+    // for making sure that a switch happens early enough.  Note that the
+    // mode is switched immediately back to its original value after consuming
+    // the command token, so that the argument parsing and/or function handler
+    // can easily access the old mode while doing their own mode switching.
+    consumeMode?: ?Mode,
 };
 
 type FunctionDefSpec = {|
@@ -128,7 +127,7 @@ export type FunctionSpec = {|
     allowedInMath: boolean,
     numOptionalArgs: number,
     infix: boolean,
-    modeSwitch: ?Mode,
+    consumeMode: ?Mode,
     // Must be specified unless it's handled directly in the parser.
     handler: ?FunctionHandler,
 |};
@@ -159,7 +158,7 @@ export default function defineFunction({
             : props.allowedInMath,
         numOptionalArgs: props.numOptionalArgs || 0,
         infix: !!props.infix,
-        modeSwitch: props.modeSwitch,
+        consumeMode: props.consumeMode,
         handler: handler,
     };
     for (let i = 0; i < names.length; ++i) {

--- a/src/defineFunction.js
+++ b/src/defineFunction.js
@@ -2,11 +2,11 @@
 import {groupTypes as htmlGroupTypes} from "./buildHTML";
 import {groupTypes as mathmlGroupTypes} from "./buildMathML";
 
-import type Parser from "./Parser" ;
-import type ParseNode from "./ParseNode" ;
+import type Parser from "./Parser";
+import type ParseNode from "./ParseNode";
 import type Options from "./Options";
-import type {ArgType, BreakToken} from "./types" ;
-import type {Token} from "./Token" ;
+import type {ArgType, BreakToken, Mode} from "./types";
+import type {Token} from "./Token";
 
 /** Context provided to function handlers for error messages. */
 export type FunctionContext = {|
@@ -14,6 +14,7 @@ export type FunctionContext = {|
     parser: Parser,
     token?: Token,
     breakOnTokenText?: BreakToken,
+    oldMode: ?Mode,
 |};
 
 // TODO: Enumerate all allowed output types.
@@ -70,6 +71,14 @@ export type FunctionPropSpec = {
 
     // Must be true if the function is an infix operator.
     infix?: boolean,
+
+    // Switch to the specified mode before consuming the command token,
+    // including before parsing the arguments.  This is useful for commands
+    // that switch between math and text mode.  `null` does not switch,
+    // while `"text"` or `"math"` will switch to the specified mode.
+    // It's the function handler's responsibility to switch back to the
+    // old mode, which is given by the oldMode field in the context object.
+    modeSwitch?: ?Mode,
 };
 
 type FunctionDefSpec = {|
@@ -119,6 +128,7 @@ export type FunctionSpec = {|
     allowedInMath: boolean,
     numOptionalArgs: number,
     infix: boolean,
+    modeSwitch: ?Mode,
     // Must be specified unless it's handled directly in the parser.
     handler: ?FunctionHandler,
 |};
@@ -149,6 +159,7 @@ export default function defineFunction({
             : props.allowedInMath,
         numOptionalArgs: props.numOptionalArgs || 0,
         infix: !!props.infix,
+        modeSwitch: props.modeSwitch,
         handler: handler,
     };
     for (let i = 0; i < names.length; ++i) {

--- a/src/functions.js
+++ b/src/functions.js
@@ -33,6 +33,8 @@ import "./functions/color";
 
 import "./functions/text";
 
+import "./functions/math";
+
 import "./functions/enclose";
 
 import "./functions/overline";
@@ -298,35 +300,3 @@ import "./functions/href";
 
 // MathChoice
 import "./functions/mathchoice";
-
-// Switching from text mode back to math mode
-defineFunction(["\\(", "$"], {
-    numArgs: 0,
-    allowedInText: true,
-    allowedInMath: false,
-    modeSwitch: "math",
-}, function(context, args) {
-    const {funcName, parser, oldMode} = context;
-    const close = (funcName === "\\(" ? "\\)" : "$");
-    const body = parser.parseExpression(false, close);
-    // We can't expand the next symbol after the closing $ until after
-    // switching modes back.  So don't consume within expect.
-    parser.expect(close, false);
-    if (oldMode) { // should always be defined for a modeSwitch function
-        parser.switchMode(oldMode);
-    }
-    parser.consume();
-    return {
-        type: "styling",
-        style: "text",
-        value: body,
-    };
-});
-
-defineFunction(["\\)", "\\]"], {
-    numArgs: 0,
-    allowedInText: true,
-    allowedInMath: false,
-}, function(context, args) {
-    throw new ParseError(`Mismatched ${context.funcName}`);
-});

--- a/src/functions.js
+++ b/src/functions.js
@@ -298,3 +298,10 @@ import "./functions/href";
 
 // MathChoice
 import "./functions/mathchoice";
+
+// \( and \) are handled in Parser.js, so if we get here, it's an error.
+defineFunction(["\\(", "\\)"], {
+    allowedInText: true,
+}, function(context, args) {
+    throw new ParseError(`Mismatched ${context.funcName}`);
+});

--- a/src/functions/math.js
+++ b/src/functions/math.js
@@ -1,4 +1,5 @@
 import defineFunction from "../defineFunction";
+import ParseError from "../ParseError";
 
 // Switching from text mode back to math mode
 defineFunction({
@@ -10,15 +11,15 @@ defineFunction({
         modeSwitch: "math",
     },
     handler(context, args) {
-        const {funcName, parser, oldMode} = context;
+        const {funcName, parser} = context;
+        const outerMode = parser.mode;
+        parser.switchMode("math");
         const close = (funcName === "\\(" ? "\\)" : "$");
         const body = parser.parseExpression(false, close);
         // We can't expand the next symbol after the closing $ until after
         // switching modes back.  So don't consume within expect.
         parser.expect(close, false);
-        if (oldMode) { // should always be defined for a modeSwitch function
-            parser.switchMode(oldMode);
-        }
+        parser.switchMode(outerMode);
         parser.consume();
         return {
             type: "styling",

--- a/src/functions/math.js
+++ b/src/functions/math.js
@@ -1,3 +1,4 @@
+// @flow
 import defineFunction from "../defineFunction";
 import ParseError from "../ParseError";
 

--- a/src/functions/math.js
+++ b/src/functions/math.js
@@ -1,0 +1,41 @@
+import defineFunction from "../defineFunction";
+
+// Switching from text mode back to math mode
+defineFunction({
+    names: ["\\(", "$"],
+    props: {
+        numArgs: 0,
+        allowedInText: true,
+        allowedInMath: false,
+        modeSwitch: "math",
+    },
+    handler(context, args) {
+        const {funcName, parser, oldMode} = context;
+        const close = (funcName === "\\(" ? "\\)" : "$");
+        const body = parser.parseExpression(false, close);
+        // We can't expand the next symbol after the closing $ until after
+        // switching modes back.  So don't consume within expect.
+        parser.expect(close, false);
+        if (oldMode) { // should always be defined for a modeSwitch function
+            parser.switchMode(oldMode);
+        }
+        parser.consume();
+        return {
+            type: "styling",
+            style: "text",
+            value: body,
+        };
+    },
+});
+
+defineFunction({
+    names: ["\\)", "\\]"],
+    props: {
+        numArgs: 0,
+        allowedInText: true,
+        allowedInMath: false,
+    },
+    handler(context, args) {
+        throw new ParseError(`Mismatched ${context.funcName}`);
+    },
+});

--- a/src/functions/math.js
+++ b/src/functions/math.js
@@ -29,6 +29,7 @@ defineFunction({
     },
 });
 
+// Check for extra closing math delimiters
 defineFunction({
     names: ["\\)", "\\]"],
     props: {

--- a/src/functions/math.js
+++ b/src/functions/math.js
@@ -8,7 +8,7 @@ defineFunction({
         numArgs: 0,
         allowedInText: true,
         allowedInMath: false,
-        modeSwitch: "math",
+        consumeMode: "math",
     },
     handler(context, args) {
         const {funcName, parser} = context;

--- a/src/functions/text.js
+++ b/src/functions/text.js
@@ -35,13 +35,18 @@ defineFunction({
         argTypes: ["text"],
         greediness: 2,
         allowedInText: true,
+        modeSwitch: "text",
     },
     handler(context, args) {
+        const {funcName, parser, oldMode} = context;
         const body = args[0];
+        if (oldMode) { // should always be defined for a modeSwitch function
+            parser.switchMode(oldMode);
+        }
         return {
             type: "text",
             body: ordargument(body),
-            font: context.funcName,
+            font: funcName,
         };
     },
     htmlBuilder(group, options) {

--- a/src/functions/text.js
+++ b/src/functions/text.js
@@ -35,18 +35,14 @@ defineFunction({
         argTypes: ["text"],
         greediness: 2,
         allowedInText: true,
-        modeSwitch: "text",
+        consumeMode: "text",
     },
     handler(context, args) {
-        const {funcName, parser, oldMode} = context;
         const body = args[0];
-        if (oldMode) { // should always be defined for a modeSwitch function
-            parser.switchMode(oldMode);
-        }
         return {
             type: "text",
             body: ordargument(body),
-            font: funcName,
+            font: context.funcName,
         };
     },
     htmlBuilder(group, options) {

--- a/src/types.js
+++ b/src/types.js
@@ -23,4 +23,5 @@ export type ArgType = "color" | "size" | "url" | "original" | Mode;
 // LaTeX display style.
 export type StyleStr = "text" | "display";
 
-export type BreakToken = "]" | "}" | "$";
+// Allowable token text for "break" arguments in parser
+export type BreakToken = "]" | "}" | "$" | "\\)";

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -903,8 +903,8 @@ describe("A text parser", function() {
     });
 
     it("should not mix $ and \\(..\\)", function() {
-        expect("$x\\)").toNotParse();
-        expect("\\(x$").toNotParse();
+        expect("\\text{$x\\)}").toNotParse();
+        expect("\\text{\\(x$}").toNotParse();
     });
 
     it("should parse spacing functions", function() {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -875,6 +875,13 @@ describe("A text parser", function() {
         expect("\\text{graph: \\(y = mx + b\\)}").toParse();
     });
 
+    it("should parse math within text within math within text", function() {
+        expect("\\text{hello $x + \\text{world $y$} + z$}").toParse();
+        expect("\\text{hello \\(x + \\text{world $y$} + z\\)}").toParse();
+        expect("\\text{hello $x + \\text{world \\(y\\)} + z$}").toParse();
+        expect("\\text{hello \\(x + \\text{world \\(y\\)} + z\\)}").toParse();
+    });
+
     it("should forbid \\( within math mode", function() {
         expect("\\(").toNotParse();
         expect("\\text{$\\(x\\)$}").toNotParse();
@@ -893,6 +900,11 @@ describe("A text parser", function() {
     it("should detect unbalanced $", function() {
         expect("$").toNotParse();
         expect("\\text{$}").toNotParse();
+    });
+
+    it("should not mix $ and \\(..\\)", function() {
+        expect("$x\\)").toNotParse();
+        expect("\\(x$").toNotParse();
     });
 
     it("should parse spacing functions", function() {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2861,8 +2861,8 @@ describe("A macro expander", function() {
             {"\\mode": "\\TextOrMath{t}{m}"});
     });
 
-    // TODO(edemaine): This doesn't work yet.  Parses like `\text math`,
-    // which doesn't even treat all four letters as an argument.
+    // TODO(edemaine): This doesn't work yet.  Parses like `\text text`,
+    // which doesn't treat all four letters as an argument.
     //it("\\TextOrMath should work in a macro passed to \\text", function() {
     //    compareParseTree("\\text\\mode", "\\text{text}",
     //        {"\\mode": "\\TextOrMath{text}{math}"});


### PR DESCRIPTION
* Fix #1212 by supporting `\(...\)` in addition to `$...$` inline math nested inside `\text`. This turned out to be harder than one would think because of the way `$` was being handled specially, while `\(` needed to be handled as a function, which immediately consumed the `\(` token, which meant that the first following token got consumed in text mode instead of math mode (unlike `$` where we could switch the mode before consumption).
* Added new `consumeMode` setting for functions which tells the parser to switch modes just for the consumption of the command token.
* Now that we're working with functions, move all the `$` handling code into `functions/math.js`.  Somewhat bizarrely, we can define `$` as a function (nearly identical to `\(`) and it all works (just like we can have single-character macros).  This move removed a lot of messy stuff from `Parser.js`: `ParsedDollar`, `ParsedFuncOrArgOrDollar`, `newDollar`, `assertFuncOrArg`, and at least three explicit checks for `if (... === "$")`.
* Moved the `consume()` for the command token from `parseSymbol` to `parseGivenFunction`.  This ended up not being strictly necessary, but seems conceptually cleaner.
* Partially address #1027 by setting `consumeMode: "text"` for `\text` commands.  As a result, `\text` now instantly switches the mode to `"text"`, so even an unbraced macro argument will properly detect text mode.  I added a test for this, which is a slightly weaker form of #1027.