### PR TITLE
Support Unicode Mathematical Alphanumeric Symbols

### DIFF
--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -10,6 +10,7 @@ import builtinMacros from "./macros";
 import type {Mode} from "./types";
 import ParseError from "./ParseError";
 import objectAssign from "object-assign";
+import {expandWideChar} from "./wide-character";
 
 import type {MacroContextInterface, MacroMap, MacroExpansion} from "./macros";
 
@@ -143,12 +144,12 @@ export default class MacroExpander implements MacroContextInterface {
     expandOnce(): Token | Token[] {
         const topToken = this.popToken();
         const name = topToken.text;
-        const isMacro = (name.charAt(0) === "\\");
+        const isMacro = (name.charAt(0) === "\\" || name.charAt(0) === "\uD835");
         if (isMacro && controlWordRegex.test(name)) {
             // Consume all spaces after \macro (but not \\, \', etc.)
             this.consumeSpaces();
         }
-        if (!this.macros.hasOwnProperty(name)) {
+        if (!(this.macros.hasOwnProperty(name) || name.charAt(0) === "\uD835")) {
             // Fully expanded
             this.pushToken(topToken);
             return topToken;
@@ -226,9 +227,16 @@ export default class MacroExpander implements MacroContextInterface {
      * Caches macro expansions for those that were defined simple TeX strings.
      */
     _getExpansion(name: string): MacroExpansion {
-        const definition = this.macros[name];
-        const expansion =
-            typeof definition === "function" ? definition(this) : definition;
+        let expansion;
+        if (name.charAt(0) === "\uD835") {
+            // Surrogate pair. We support Unicode range 1D400–1D7FF,
+            // Mathematical Alphanumeric Symbols.
+            expansion = expandWideChar(name, this.mode);
+        } else {
+            const definition = this.macros[name];
+            expansion =
+                typeof definition === "function" ? definition(this) : definition;
+        }
         if (typeof expansion === "string") {
             let numArgs = 0;
             if (expansion.indexOf("#") !== -1) {
@@ -257,4 +265,3 @@ export default class MacroExpander implements MacroContextInterface {
         return expansion;
     }
 }
-

--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -228,12 +228,13 @@ export default class MacroExpander implements MacroContextInterface {
      */
     _getExpansion(name: string): MacroExpansion {
         let expansion;
+        let definition;
         if (name.charAt(0) === "\uD835") {
             // Surrogate pair. We support Unicode range 1D400–1D7FF,
             // Mathematical Alphanumeric Symbols.
             expansion = expandWideChar(name, this.mode);
         } else {
-            const definition = this.macros[name];
+            definition = this.macros[name];
             expansion =
                 typeof definition === "function" ? definition(this) : definition;
         }

--- a/src/fontMetrics.js
+++ b/src/fontMetrics.js
@@ -204,17 +204,22 @@ const getCharacterMetrics = function(
     }
     let metrics = metricMap[font][ch];
 
-    if (!metrics && mode === 'text') {
-        // We don't typically have font metrics for Asian scripts.
-        // But since we support them in text mode, we need to return
-        // some sort of metrics.
-        // So if the character is in a script we support but we
-        // don't have metrics for it, just use the metrics for
-        // the Latin capital letter M. This is close enough because
-        // we (currently) only care about the height of the glpyh
-        // not its width.
-        if (supportedCodepoint(ch)) {
-            metrics = metricMap[font][77]; // 77 is the charcode for 'M'
+    if (!metrics) {
+        if (mode === 'text') {
+            // We don't typically have font metrics for Asian scripts.
+            // But since we support them in text mode, we need to return
+            // some sort of metrics.
+            // So if the character is in a script we support but we
+            // don't have metrics for it, just use the metrics for
+            // the Latin capital letter M. This is close enough because
+            // we (currently) only care about the height of the glpyh
+            // not its width.
+            if (supportedCodepoint(ch)) {
+                metrics = metricMap[font][77]; // 77 is the charcode for 'M'
+            }
+        } else if (!metrics && ch[0] === "\uD835") {
+            // Use the same trick here as we use for Asian scripts above.
+            metrics = metricMap[font][77];
         }
     }
 

--- a/src/fontMetrics.js
+++ b/src/fontMetrics.js
@@ -217,7 +217,7 @@ const getCharacterMetrics = function(
             if (supportedCodepoint(ch)) {
                 metrics = metricMap[font][77]; // 77 is the charcode for 'M'
             }
-        } else if (!metrics && ch[0] === "\uD835") {
+        } else if (!metrics && ch === 0xD835) {
             // Use the same trick here as we use for Asian scripts above.
             metrics = metricMap[font][77];
         }

--- a/src/functions.js
+++ b/src/functions.js
@@ -295,6 +295,9 @@ defineFunction(["\\raisebox"], {
 
 import "./functions/verb";
 
+// Private function for handling wide characters.
+import "./functions/sysfont";
+
 // Hyperlinks
 import "./functions/href";
 

--- a/src/functions/sysfont.js
+++ b/src/functions/sysfont.js
@@ -1,7 +1,6 @@
 // @flow
 import defineFunction from "../defineFunction";
 import buildCommon from "../buildCommon";
-import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
 
 // This little file is here to clean up the mess left when wide-character.js
@@ -15,7 +14,7 @@ const htmlBuilder = (group, options) => {
 };
 
 const mathmlBuilder = (group, options) => {
-    return mml.makeText(group.value.value, group.mode)
+    return mml.makeText(group.value.value, group.mode);
 };
 
 defineFunction({

--- a/src/functions/sysfont.js
+++ b/src/functions/sysfont.js
@@ -1,0 +1,49 @@
+// @flow
+import defineFunction from "../defineFunction";
+import buildCommon from "../buildCommon";
+import * as html from "../buildHTML";
+import * as mml from "../buildMathML";
+
+// This little file is here to clean up the mess left when wide-character.js
+// was unable to process a wide character in the Unicode range U+1D400 to
+// U+1D7FF. Here we execute the fall-back plan, which is to render the
+// character in a system font.
+
+const htmlBuilder = (group, options) => {
+    const str = group.value.value;
+    return buildCommon.makeSymbol(str, "Main-Regular", group.mode, options);
+};
+
+const mathmlBuilder = (group, options) => {
+    return mml.makeText(group.value.value, group.mode)
+};
+
+defineFunction({
+    type: "sysfont",
+    names: ["\\sysfont"],
+    props: {
+        numArgs: 1,
+        allowedInText: true,
+        allowedInMath: true,
+    },
+    handler: (context, args) => {
+        // Function expandWideChar() did not return the wide character.
+        // That would have created an infinite loop. Instead, it
+        // returned the low surrogate of the wide character.
+
+        // Reconstruct the string character from its low surrogate.
+        const valArray = args[0].value;
+        let lowSurrogate = "";
+        for (let i = 0; i < valArray.length; i++) {
+            lowSurrogate += valArray[i].value;
+        }
+        const str = String.fromCharCode(0xD835, parseInt(lowSurrogate));
+
+        return {
+            type: "sysfont",
+            value: str,
+        };
+    },
+    htmlBuilder,
+    mathmlBuilder,
+});

--- a/src/unicodeScripts.js
+++ b/src/unicodeScripts.js
@@ -5,6 +5,8 @@
  * support. To add new scripts or families, just add a new entry to the
  * scriptData array below. Adding scripts to the scriptData array allows
  * characters from that script to appear in \text{} environments.
+ *
+ * See wide-characters.js for surrogate pairs.
  */
 
 /**

--- a/src/wide-character.js
+++ b/src/wide-character.js
@@ -1,0 +1,173 @@
+// @flow
+
+/**
+ * This file provides support for Unicode range U+1D400 to U+1D7FF,
+ * Mathematical Alphanumeric Symbols.
+ *
+ * Function expandWideChar takes a wide character as input, expands it
+ * into a macro with the appropriate font, and returns it to MacroExpander.js.
+ */
+
+import type {Mode} from "./types";
+import ParseError from "./ParseError";
+
+/**
+ * Data below is from https://www.unicode.org/charts/PDF/U1D400.pdf
+ * That document sorts characters into groups by font type, say bold or italic.
+ *
+ * In array wideCharData, each subarray consists four elements:
+ *      * The Unicode code point at the end of a character group.
+ *      * The font specification of that group when in math mode.
+ *      * The font specification of that group when in text mode.
+ *      * The offset from a Unicode code point to the character code of
+ *            the corresponding plain text letter.
+ */
+
+const wideCharData: Array<Array<number, string, string, number>> = [
+    [0x1D419, "\\mathbf{", "\\textbf{", 0x1D3BF],       // A-Z bold upright
+    [0x1D433, "\\mathbf{", "\\textbf{", 0x1D3B9],       // a-z bold upright
+    [0x1D44D, "", "\\textit{", 0x1D3F3],                // A-Z italic
+    [0x1D467, "", "\\textit{", 0x1D3ED],                // a-z italic
+    [0x1D481, "\\bm{", "\\textit{\\textbf{", 0x1D427],  // A-Z bold italic
+    [0x1D49B, "\\bm{", "\\textit{\\textbf{", 0x1D421],  // a-z bold italic
+
+    // Map fancy A-Z letters to script, not calligraphic.
+    // This aligns with unicode-math and math fonts (except Cambria Math).
+    // There is no KaTeX function for script in text mode.
+    // So in text mode, we fall back to system font.
+    [0x1D4B5, "\\mathscr{", "systemfont", 0x1D45B],     // A-Z script
+
+    // KaTeX fonts don't include script or calligraphic for letters a-z.
+    [0x1D4CF, "systemfont", "systemfont", 0x1D455],     //  a-z script
+
+    // KaTeX fonts don't include bold script.
+    [0x1D4E9, "systemfont", "systemfont", 0x1D48F],     // A-Z bold script
+
+    // No KaTeX script or calligraphic font with letters a-z.
+    // Note: if the system picks Cambria Math as a fallback, this
+    //       will render in calligraphic. Other math fonts use script.
+    [0x1D503, "systemfont", "systemfont", 0x1D489],     // a-z bold script.
+
+    [0x1D51D, "\\mathfrak{", "systemfont", 0x1D4C3],    // A-Z Fraktur
+    [0x1D537, "\\mathfrak{", "systemfont", 0x1D4BD],    // a-z Fraktur
+    [0x1D551, "\\mathbb{", "systemfont", 0x1D4F7],      // A-Z double-struck
+
+    // "k" is the only lower case double-struck letter in KaTeX fonts.
+    [0x1D56B, "systemfont", "systemfont", 0x1D4F1],     // a-z double-struck
+
+    // \textfrak{\textbf{...}} is not working.
+    [0x1D585, "systemfont", "systemfont", 0x1D52B],   // A-Z bold Fraktur
+    [0x1D59F, "systemfont", "systemfont", 0x1D525],   // a-z bold Fraktur
+
+    [0x1D5B9, "\\mathsf{", "\\textsf{", 0x1D55F],     // A-Z sans-serif
+    [0x1D5D3, "\\mathsf{", "\\textsf{", 0x1D559],     // a-z sans-serif
+    [0x1D5ED, "\\mathord{\\textsf{\\textbf{",
+        "\\textsf{\\textbf{", 0x1D593],               // A-Z bold sans-serif
+    [0x1D607, "\\mathord{\\textsf{\\textbf{",
+        "\\textsf{\\textbf{", 0x1D58D],               // a-z bold sans-serif
+    [0x1D621, "\\mathord{\\textsf{\\textit{",
+        "\\textsf{\\textit{", 0x1D5C7],               // A-Z italic sans-serif
+    [0x1D63B, "\\mathord{\\textsf{\\textit{",
+        "\\textsf{\\textit{", 0x1D5C1],               // a-z italic sans-serif
+
+    // KaTeX fonts don't include bold italic sans.
+    [0x1D655, "systemfont", "systemfont", 0x1D5FB],   // A-Z bold italic sans
+    [0x1D66F, "systemfont", "systemfont", 0x1D5F5],   // a-z bold italic sans
+
+    [0x1D689, "\\mathtt{", "\\texttt{", 0x1D62F],     // A-Z monospace
+    [0x1D6A3, "\\mathtt{", "\\texttt{", 0x1D629],     // a-z monospace
+    [0x1D6A4, "\u0131", "\u0131", -1],                // dotless i italic
+    [0x1D6A5, "\u0237", "\u0237", -1],                // dotless j italic
+
+    [0x1D7D7, "\\mathbf{", "\\textbf{", 0x1D79E],     // 0-9 bold
+
+    // KaTeX fonts don't include double-struck numerals.
+    [0x1D7E1, "systemfont", "systemfont", 0x1D7A8],   // 0-9 double-struck
+
+    [0x1D7EB, "\\mathsf{", "\\textsf{", 0x1D7B2],     // 0-9 sans-serif
+    [0x1D7F5, "\\mathord{\\textsf{\\textbf{",
+        "\\textsf{\\textbf{", 0x1D7BC],               // 0-9 bold sans-serif
+    [0x1D7FF, "\\mathtt{", "\\texttt{", 0x1D7C6],     // 0-9 monospace
+];
+
+export const expandWideChar = function(wideChar: string, mode: Mode): string {
+    // IE doesn't support codePointAt(). So work with the surrogate pair.
+    const H = wideChar.charCodeAt(0);    // high surrogate
+    const L = wideChar.charCodeAt(1);    // low surrogate
+    const codePoint = ((H - 0xD800) * 0x400) + (L - 0xDC00) + 0x10000;
+
+    if (codePoint < 0x1D400 || codePoint > 0x1D7FF) {
+        // We don't support any wide characters outside 1D400–1D7FF.
+        throw new ParseError("Unsupported character: " + wideChar);
+    }
+
+    if (0x1D6A5 < codePoint && codePoint < 0x1D7CE) {
+        // Greek letter. Return a private function to render the character
+        // in a system font. Note that we can't return wideChar. MacroExpander
+        // would send it right back here and we would have an infinite loop.
+        // So we'll return the low surrogate. Function \sysfont knows how
+        // to reconstruct the character from the low surrogate.
+
+        // TODO: Fill out the rest of wideCharData so Greek letters
+        //       will render in KaTeX fonts.
+        return "\\sysfont{" + L + "}";
+    }
+
+    let i;
+    let iRow;
+
+    // Determine the relevant row of the wideCharData array.
+    if (codePoint < 0x1D6A4) {
+        // Below 0x1D6A4, wideCharData contains exactly 26 chars on each row.
+        // So we can calculate the relevant row. No traverse necessary.
+        iRow = Math.floor((codePoint - 0x1D400) / 26);
+
+        // If you prepend or insert any new rows into wideCharData,
+        // then please update the equations above and below.
+
+    } else if (codePoint > 0x1D7CD) {
+        // Above 1D7CD there are ten digits, 0-9, per row.
+        iRow = Math.floor((codePoint - 0x1D7CE) / 10) + 28;
+
+    } else {
+        // Traverse the wideCharData array to find the relevant row.
+        for (i = 26; i < wideCharData.length; i++) {
+            if (codePoint <= wideCharData[i][0]) {
+                iRow = i;
+                break;
+            }
+        }
+    }
+
+    // Find the plain text letter that corresponds to wideChar.
+    const offset = wideCharData[iRow][3];
+    if (offset === -1) {
+        // special item, e.g., \imath
+        return mode === "math" ? wideCharData[iRow][1] :
+            wideCharData[iRow][2];
+    }
+    const letter = String.fromCharCode(codePoint - offset);
+
+    // Get the appropriate font.
+    const format = mode === "math" ? wideCharData[iRow][1] :
+            wideCharData[iRow][2];
+
+    if (format === "systemfont") {
+        // There is no macro available that will render wideChar in
+        // the proper KaTeX font. Fall back to a system font.
+        return "\\sysfont{" + L + "}";
+    }
+
+    // Finish with the closing delimiter(s).
+    let closeDelim = "";
+    if (format.length > 0) {
+        const numBraces = format.split("{").length - 1;
+        // IE doesn't support "}".repeat(numBraces)
+        for (i = 0; i < numBraces; i++) {
+            closeDelim += "}";
+        }
+    }
+
+    // Return a macro to MacroExpander.
+    return format + letter + closeDelim;
+};

--- a/src/wide-character.js
+++ b/src/wide-character.js
@@ -23,7 +23,7 @@ import ParseError from "./ParseError";
  *            the corresponding plain text letter.
  */
 
-const wideCharData: Array<Array<number, string, string, number>> = [
+const wideCharData: Array<[number, string, string, number]> = [
     [0x1D419, "\\mathbf{", "\\textbf{", 0x1D3BF],       // A-Z bold upright
     [0x1D433, "\\mathbf{", "\\textbf{", 0x1D3B9],       // a-z bold upright
     [0x1D44D, "", "\\textit{", 0x1D3F3],                // A-Z italic
@@ -113,8 +113,8 @@ export const expandWideChar = function(wideChar: string, mode: Mode): string {
         return "\\sysfont{" + L + "}";
     }
 
-    let i;
-    let iRow;
+    let i = 0;
+    let iRow = 0;
 
     // Determine the relevant row of the wideCharData array.
     if (codePoint < 0x1D6A4) {

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2998,13 +2998,20 @@ describe("Unicode", function() {
         expect("±×÷∓∔∧∨∩∪≀⊎⊓⊔⊕⊖⊗⊘⊙⊚⊛⊝⊞⊟⊠⊡⊺⊻⊼⋇⋉⋊⋋⋌⋎⋏⋒⋓⩞\u22C5").toParse();
     });
 
-    it("should parse delimeters", function() {
+    it("should build delimeters", function() {
         expect("\\left\u230A\\frac{a}{b}\\right\u230B").toBuild();
         expect("\\left\u2308\\frac{a}{b}\\right\u2308").toBuild();
         expect("\\left\u27ee\\frac{a}{b}\\right\u27ef").toBuild();
         expect("\\left\u27e8\\frac{a}{b}\\right\u27e9").toBuild();
         expect("\\left\u23b0\\frac{a}{b}\\right\u23b1").toBuild();
         expect("┌x┐ └x┘").toBuild();
+    });
+
+    it("should build math alpha-numerics", function() {
+        expect("𝐀 𝐙 𝐚 𝐳 𝐴 𝑍 𝑎 𝑧 𝑨 𝒁 𝒂 𝒛 𝒜 𝒵 𝒶 𝓏 𝓐 𝓩 𝓪 𝔃").toBuild();
+        expect("𝔄 𝖅 𝖆 𝔷 𝔸𝕐 𝕒 𝕫 𝕬 𝖅 𝖆 𝖟 𝖠 𝖹 𝖺 𝗓 𝗔 𝗭 𝗮 𝘇 𝘈 𝘡 𝘢 𝘻").toBuild();
+        expect("𝘼 𝙕 𝙖 𝙯 𝙰 𝚉 𝚊 𝚣 𝚤 𝚥 𝟎 𝟗 𝟘 𝟡 𝟢 𝟫 𝟬 𝟵 𝟶 𝟿").toBuild();
+        expect("𝚪 𝛀 𝛂 𝛡 𝛤 𝛺 𝛼 𝜔 𝜞 𝜴 𝜶 𝝕 𝝘 𝝮 𝝰 𝞈 𝞒 𝞨 𝞪 𝟂").toBuild();
     });
 });
 


### PR DESCRIPTION
This PR adds support for Unicode range U+1D400 to U+1D7FF, [Mathematical Alphanumeric Symbols](https://www.unicode.org/charts/PDF/U1D400.pdf).