### PR TITLE
List react-katex in Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ will appear larger than 1cm in browser units.
 
 - [katex-ruby](https://github.com/glebm/katex-ruby) Provides server-side rendering and integration with popular Ruby web frameworks (Rails, Hanami, and anything that uses Sprockets).
 
+### React
+- [react-katex](https://github.com/talyssonoc/react-katex) React components that use KaTeX to typeset math expressions
+
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ will appear larger than 1cm in browser units.
 ### Angular2+
 - [ng-katex](https://github.com/garciparedes/ng-katex) Angular module to write beautiful math expressions with TeX syntax boosted by KaTeX library
 
-### Ruby
-
-- [katex-ruby](https://github.com/glebm/katex-ruby) Provides server-side rendering and integration with popular Ruby web frameworks (Rails, Hanami, and anything that uses Sprockets).
-
 ### React
 - [react-latex](https://github.com/zzish/react-latex) React component to render latex strings, based on KaTeX
 - [react-katex](https://github.com/talyssonoc/react-katex) React components that use KaTeX to typeset math expressions
+
+### Ruby
+
+- [katex-ruby](https://github.com/glebm/katex-ruby) Provides server-side rendering and integration with popular Ruby web frameworks (Rails, Hanami, and anything that uses Sprockets).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ will appear larger than 1cm in browser units.
 - [katex-ruby](https://github.com/glebm/katex-ruby) Provides server-side rendering and integration with popular Ruby web frameworks (Rails, Hanami, and anything that uses Sprockets).
 
 ### React
+- [react-latex](https://github.com/zzish/react-latex) React component to render latex strings, based on Katex
 - [react-katex](https://github.com/talyssonoc/react-katex) React components that use KaTeX to typeset math expressions
 
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ will appear larger than 1cm in browser units.
 - [katex-ruby](https://github.com/glebm/katex-ruby) Provides server-side rendering and integration with popular Ruby web frameworks (Rails, Hanami, and anything that uses Sprockets).
 
 ### React
-- [react-latex](https://github.com/zzish/react-latex) React component to render latex strings, based on Katex
+- [react-latex](https://github.com/zzish/react-latex) React component to render latex strings, based on KaTeX
 - [react-katex](https://github.com/talyssonoc/react-katex) React components that use KaTeX to typeset math expressions
 
 


### PR DESCRIPTION
Hello Khaners,

as one of the contributors of `react-katex`, React components that use KaTeX to typeset math expressions, I would like to you to list `react-katex` in your Libraries listing.

Thank you!

(fix #1155)