### PR TITLE
Replace CDN links

### DIFF
--- a/function-support.html
+++ b/function-support.html
@@ -6,9 +6,9 @@
     <title>Function Support in KaTeX</title>
     <link rel="icon" href="http://khan.github.io/favicon.ico">
 	
-	<link rel="stylesheet" href="https://unpkg.com/katex@0.9.0/dist/katex.min.css">
-	<script src="https://unpkg.com/katex@0.9.0/dist/katex.min.js"></script>
-	<script src="https://unpkg.com/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css">
+	<script src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
 
 <style>
 * { margin:0; padding:0; }  /* reset */

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <meta property="og:url" content="http://khan.github.io/KaTeX/">
     <meta property="og:image" content="http://khan.github.io/KaTeX/og_logo.png">
     <meta property="og:description" content="Simple API, no dependencies – yet super-fast on all major browsers.">
-    <link rel="stylesheet" href="https://unpkg.com/katex@0.9.0/dist/katex.min.css">
-    <script src="https://unpkg.com/katex@0.9.0/dist/katex.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
     <link href="bower_components/normalize.css/normalize.css" type="text/css" rel="stylesheet">
     <link href="bower_components/font-awesome/css/font-awesome.min.css" type="text/css" rel="stylesheet">
     <link href="main.css" type="text/css" rel="stylesheet">


### PR DESCRIPTION
I replaced the unpkg links with jsDelivr links. [jsDelivr](https://www.jsdelivr.com/package/npm/katex) works in the same way, but was built specifically for production usage. This should solve problems described in https://github.com/unpkg/unpkg/issues/88.