### PR TITLE
Fix anchor.toMarkup

### DIFF
--- a/src/domTree.js
+++ b/src/domTree.js
@@ -290,7 +290,7 @@ class anchor implements HtmlDomInterface {
         let markup = "<a";
 
         // Add the href
-        markup += `href="${markup += utils.escape(this.href)}"`;
+        markup += ` href="${utils.escape(this.href)}"`;
         // Add the class
         if (this.classes.length) {
             markup += ` class="${utils.escape(createClass(this.classes))}"`;

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -2591,6 +2591,11 @@ describe("An href command", function() {
         const ae = getParsed(`\\href{${input}}{\\alpha}`)[0];
         expect(ae.value.href).toBe(url);
     });
+
+    it("should be marked up correctly", function() {
+        const markup = katex.renderToString("\\href{http://example.com/}{example here}");
+        expect(markup).toContain("<a href=\"http://example.com/\">");
+    });
 });
 
 describe("A parser that does not throw on unsupported commands", function() {


### PR DESCRIPTION
Fixes #1245 

* Add space between `a`(tag name) and `href`(attribute name)
* Remove `this.href` appended to `markup` in the template literal