### PR TITLE
Fix lap vertical alignment?

### DIFF
--- a/src/katex.less
+++ b/src/katex.less
@@ -274,6 +274,7 @@
 
         > .inner {
             position: absolute;
+            top: 0;
         }
 
         > .fix {


### PR DESCRIPTION
This is an alternative to #1162 to fix #1234, based on a comment I made in the latter: https://github.com/Khan/KaTeX/issues/1234#issuecomment-374934462

I do not fully understand why this one-line change works, `position: absolute` always being a little mysterious, but it seems to work... at least, the examples in #1234 all seem to work correctly (I think):
```latex
\frac{a}{b}\llap| \sin\llap|1 \sqrt{\mathclap|a\mathclap|}\mathclap|
```
![image](https://user-images.githubusercontent.com/2218736/38312184-0f6770f8-37ef-11e8-96f3-33f4f34b51c0.png)
vs. current release:
![image](https://user-images.githubusercontent.com/2218736/38312216-2b123676-37ef-11e8-9156-904902eacf1c.png)

I post this here for further consideration, in particular by @ronkok, to decide whether this is actually good and could potentially simplify #1162.  He likely understands the layout better than me and can better judge.  #1162 is still necessary to fix issue #1153.