### PR TITLE
Specify height for SVG elements

### DIFF
--- a/src/katex.less
+++ b/src/katex.less
@@ -445,7 +445,7 @@
         display: block;
         position: absolute; // absolute relative to parent
         width: 100%;
-        height: 100%;
+        height: inherit;
 
         // We want to inherit colors from our environment
         fill: currentColor;

--- a/src/katex.less
+++ b/src/katex.less
@@ -445,6 +445,7 @@
         display: block;
         position: absolute; // absolute relative to parent
         width: 100%;
+        height: 100%;
 
         // We want to inherit colors from our environment
         fill: currentColor;


### PR DESCRIPTION
I ran into an issue where a low-specificity CSS rule elsewhere on the page was overriding the KaTeX SVG height, rendering fraction lines invisible. Does this seem like a reasonable addition to the style sheet?