### PR TITLE
Support \tag and \gdef

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "less": "~2.7.1",
     "less-loader": "^4.0.5",
     "mkdirp": "^0.5.1",
-    "object-assign": "^4.1.0",
     "pako": "1.0.4",
     "pre-commit": "^1.2.2",
     "query-string": "^5.1.0",

--- a/src/MacroExpander.js
+++ b/src/MacroExpander.js
@@ -9,7 +9,6 @@ import {Token} from "./Token";
 import builtinMacros from "./macros";
 import type {Mode} from "./types";
 import ParseError from "./ParseError";
-import objectAssign from "object-assign";
 
 import type {MacroContextInterface, MacroMap, MacroExpansion} from "./macros";
 
@@ -21,7 +20,7 @@ export default class MacroExpander implements MacroContextInterface {
 
     constructor(input: string, macros: MacroMap, mode: Mode) {
         this.lexer = new Lexer(input);
-        this.macros = objectAssign({}, builtinMacros, macros);
+        this.macros = Object.assign({}, builtinMacros, macros);
         this.mode = mode;
         this.stack = []; // contains tokens in REVERSE order
     }

--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -668,8 +668,7 @@ export default function buildHTML(tree, options) {
     // Build the expression contained in the tree
     const expression = buildExpression(tree, options, true);
 
-    const htmlNode = makeSpan(["katex-html"], []);
-    htmlNode.setAttribute("aria-hidden", "true");
+    const children = [];
 
     // Create one base node for each chunk between potential line breaks.
     // The TeXBook [p.173] says "A formula will be broken only after a
@@ -697,14 +696,25 @@ export default function buildHTML(tree, options) {
             }
             // Don't allow break if \nobreak among the post-operator glue.
             if (!nobreak) {
-                htmlNode.children.push(buildHTMLUnbreakable(parts, options));
+                children.push(buildHTMLUnbreakable(parts, options));
                 parts = [];
             }
         }
     }
     if (parts.length > 0) {
-        htmlNode.children.push(buildHTMLUnbreakable(parts, options));
+        children.push(buildHTMLUnbreakable(parts, options));
     }
+
+    const htmlNode = makeSpan(["katex-html"], children);
+    htmlNode.setAttribute("aria-hidden", "true");
+
+    const strut = makeSpan(["strut"]);
+    strut.style.height = (htmlNode.height + htmlNode.depth) + "em";
+    strut.style.verticalAlign = (-htmlNode.depth) + "em";
+    htmlNode.children.push(makeSpan(["tag"], [
+        strut,
+        buildCommon.mathsym("*", "math"),
+    ]));
 
     return htmlNode;
 }

--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -708,13 +708,24 @@ export default function buildHTML(tree, options) {
     const htmlNode = makeSpan(["katex-html"], children);
     htmlNode.setAttribute("aria-hidden", "true");
 
-    const strut = makeSpan(["strut"]);
-    strut.style.height = (htmlNode.height + htmlNode.depth) + "em";
-    strut.style.verticalAlign = (-htmlNode.depth) + "em";
-    htmlNode.children.push(makeSpan(["tag"], [
-        strut,
-        buildCommon.mathsym("*", "math"),
-    ]));
+    // \tag output is guaranteed to be the last node of the last unbreakable.
+    // Bring it out to the top level.
+    if (children && children.length > 0) {
+        const lastChild = children[children.length - 1];
+        if (lastChild && lastChild.children.length > 0) {
+            const lastNode = lastChild.children[lastChild.children.length - 1];
+            if (lastNode.hasClass("tag")) {
+                lastChild.children.pop();
+                const strut = makeSpan(["strut"]);
+                strut.style.height = (htmlNode.height + htmlNode.depth) + "em";
+                strut.style.verticalAlign = (-htmlNode.depth) + "em";
+                htmlNode.children.push(makeSpan(["tag"], [
+                    strut,
+                    lastNode,
+                ]));
+            }
+        }
+    }
 
     return htmlNode;
 }

--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -29,6 +29,33 @@ export const makeText = function(text, mode) {
     return new mathMLTree.TextNode(text);
 };
 
+export const makeTextRow = function(body, options) {
+    // Convert each element of the body into MathML, and combine consecutive
+    // <mtext> outputs into a single <mtext> tag.  In this way, we don't
+    // nest non-text items (e.g., $nested-math$) within an <mtext>.
+    const inner = [];
+    let currentText = null;
+    for (let i = 0; i < body.length; i++) {
+        const group = buildGroup(body[i], options);
+        if (group.type === 'mtext' && currentText !== null) {
+            Array.prototype.push.apply(currentText.children, group.children);
+        } else {
+            inner.push(group);
+            if (group.type === 'mtext') {
+                currentText = group;
+            }
+        }
+    }
+
+    // If there is a single tag in the end (presumably <mtext>),
+    // just return it.  Otherwise, wrap them in an <mrow>.
+    if (inner.length === 1) {
+        return inner[0];
+    } else {
+        return new mathMLTree.MathNode("mrow", inner);
+    }
+};
+
 /**
  * Returns the math variant as a string or null if none is required.
  */

--- a/src/functions.js
+++ b/src/functions.js
@@ -37,6 +37,8 @@ import "./functions/color";
 
 import "./functions/text";
 
+import "./functions/tag";
+
 import "./functions/math";
 
 import "./functions/enclose";

--- a/src/functions/text.js
+++ b/src/functions/text.js
@@ -1,7 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
 import buildCommon from "../buildCommon";
-import mathMLTree from "../mathMLTree";
 
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -62,31 +61,6 @@ defineFunction({
             inner, newOptions);
     },
     mathmlBuilder(group, options) {
-        const body = group.value.body;
-
-        // Convert each element of the body into MathML, and combine consecutive
-        // <mtext> outputs into a single <mtext> tag.  In this way, we don't
-        // nest non-text items (e.g., $nested-math$) within an <mtext>.
-        const inner = [];
-        let currentText = null;
-        for (let i = 0; i < body.length; i++) {
-            const group = mml.buildGroup(body[i], options);
-            if (group.type === 'mtext' && currentText != null) {
-                Array.prototype.push.apply(currentText.children, group.children);
-            } else {
-                inner.push(group);
-                if (group.type === 'mtext') {
-                    currentText = group;
-                }
-            }
-        }
-
-        // If there is a single tag in the end (presumably <mtext>),
-        // just return it.  Otherwise, wrap them in an <mrow>.
-        if (inner.length === 1) {
-            return inner[0];
-        } else {
-            return new mathMLTree.MathNode("mrow", inner);
-        }
+        return mml.makeTextRow(group.value.body, options);
     },
 });

--- a/src/katex.less
+++ b/src/katex.less
@@ -23,12 +23,17 @@
     text-align: center;
 
     > .katex {
-        display: inline-block;
-        text-align: initial;
+        display: block;
+        text-align: center;
         white-space: nowrap;
 
         > .katex-html {
-            display: inline-block;
+            display: block;
+
+            > .tag {
+                position: absolute;
+                right: 0px;
+            }
         }
     }
 }

--- a/src/macros.js
+++ b/src/macros.js
@@ -118,7 +118,7 @@ defineMacro("\\gdef", function(context) {
     while (arg.length === 1 && arg[0].text === "#") {
         arg = context.consumeArgs(1)[0];
         if (arg.length !== 1) {
-            throw new ParseError(`Invalid argument number "${arg}"`);
+            throw new ParseError(`Invalid argument number length "${arg.length}"`);
         }
         if (!(/^[1-9]$/.test(arg[0].text))) {
             throw new ParseError(`Invalid argument number "${arg[0].text}"`);

--- a/src/macros.js
+++ b/src/macros.js
@@ -396,6 +396,17 @@ defineMacro("\\thinspace", "\\,");    //   \let\thinspace\,
 defineMacro("\\medspace", "\\:");     //   \let\medspace\:
 defineMacro("\\thickspace", "\\;");   //   \let\thickspace\;
 
+// \tag@in@display form of \tag
+defineMacro("\\tag", "\\@ifstar\\tag@literal\\tag@paren");
+defineMacro("\\tag@paren", "\\tag@literal{(#1)}");
+defineMacro("\\tag@literal", (context) => {
+    if (context.macros["\\df@tag"] && context.macros["\\df@tag"].tokens &&
+        context.macros["\\df@tag"].tokens.length > 0) {
+        throw new ParseError("Multiple \\tag");
+    }
+    return "\\gdef\\df@tag{\\tag@{#1}}";
+});
+
 //////////////////////////////////////////////////////////////////////
 // LaTeX source2e
 

--- a/src/parseTree.js
+++ b/src/parseTree.js
@@ -16,6 +16,10 @@ const parseTree = function(toParse: string, settings: Settings): ParseNode<*>[] 
     if (!(typeof toParse === 'string' || toParse instanceof String)) {
         throw new TypeError('KaTeX can only parse string typed expression');
     }
+    // Render any tag at end of displayMode formula
+    if (settings.displayMode) {
+        toParse = "\\gdef\\df@tag{}" + toParse + "\\df@tag";
+    }
     const parser = new Parser(toParse, settings);
 
     return parser.parse();


### PR DESCRIPTION
The primary goal here was to implement `\tag` and thereby fix #899.  As discussed in that issue, I've tried a variety of ways to lay out the tag.  My recent experience with struts opened up some new possibilities, though, and I found a nice layout that (a) centers the equation as before and (b) properly aligns the tag.  The solution is to `position: absolute; right: 0px` the tag, but add a strut matching the equation to make it vertically aligned correctly. However, it's possible for the tag to overlap the equation; no floating behavior.  (I don't think it's possible to get the proper centering and have float behavior, without client-side JavaScript.)  But it was always possible for the equation to be too big for the line anyway.

`\tag` has a delayed effect (the argument gets rendered at the end of the display formula), which is implemented in LaTeX via the macro system.  So I implemented some basic TeX-side macros (as requested in #250): you can now define a macro via `\gdef\foo{...}` or `\gdef\foo#1#2{...}`.  It's a bit restrictive, but essentially opens up the existing macro functionality from the TeX input side, which is cool in its own right.  This is a good step toward `\def` and `\setlength` -- I have a plan for those.

Demos:

![image](https://user-images.githubusercontent.com/2218736/39959708-96d839d4-55e3-11e8-9f4f-02f8e70de4b8.png)

![image](https://user-images.githubusercontent.com/2218736/39959710-a71171ee-55e3-11e8-8d5f-709248a3a36d.png)
