### PR TITLE
Specify flow output types for htmlBuilder and mathmlBuilder.

### DIFF
--- a/src/defineEnvironment.js
+++ b/src/defineEnvironment.js
@@ -7,7 +7,9 @@ import ParseNode from "./ParseNode";
 
 import type Parser from "./Parser";
 import type {ArgType, Mode} from "./types";
+import type {HtmlDomNode} from "./domTree";
 import type {NodeType} from "./ParseNode";
+import type {MathNode} from "./mathMLTree";
 
 /**
  * The context contains the following properties:
@@ -84,13 +86,11 @@ type EnvDefSpec<NODETYPE: NodeType> = {|
 
     // This function returns an object representing the DOM structure to be
     // created when rendering the defined LaTeX function.
-    // TODO: Port buildHTML to flow and make the return type explicit.
-    htmlBuilder: (group: ParseNode<NODETYPE>, options: Options) => *,
+    htmlBuilder: (group: ParseNode<NODETYPE>, options: Options) => HtmlDomNode,
 
     // This function returns an object representing the MathML structure to be
     // created when rendering the defined LaTeX function.
-    // TODO: Port buildMathML to flow and make the return type explicit.
-    mathmlBuilder: (group: ParseNode<NODETYPE>, options: Options) => *,
+    mathmlBuilder: (group: ParseNode<NODETYPE>, options: Options) => MathNode,
 |};
 
 export default function defineEnvironment<NODETYPE: NodeType>({

--- a/src/defineFunction.js
+++ b/src/defineFunction.js
@@ -2,13 +2,15 @@
 import {groupTypes as htmlGroupTypes} from "./buildHTML";
 import {groupTypes as mathmlGroupTypes} from "./buildMathML";
 import {checkNodeType} from "./ParseNode";
+import domTree from "./domTree";
 
 import type Parser from "./Parser";
-import type ParseNode from "./ParseNode";
-import type {NodeType, NodeValue} from "./ParseNode";
+import type ParseNode, {NodeType, NodeValue} from "./ParseNode";
 import type Options from "./Options";
 import type {ArgType, BreakToken, Mode} from "./types";
+import type {HtmlDomNode} from "./domTree";
 import type {Token} from "./Token";
+import type {MathNode, TextNode} from "./mathMLTree";
 
 /** Context provided to function handlers for error messages. */
 export type FunctionContext = {|
@@ -104,13 +106,14 @@ type FunctionDefSpec<NODETYPE: NodeType> = {|
 
     // This function returns an object representing the DOM structure to be
     // created when rendering the defined LaTeX function.
-    // TODO: Make return type explicit.
-    htmlBuilder?: (group: ParseNode<NODETYPE>, options: Options) => *,
+    htmlBuilder?: (group: ParseNode<NODETYPE>, options: Options) => HtmlDomNode,
 
     // This function returns an object representing the MathML structure to be
     // created when rendering the defined LaTeX function.
-    // TODO: Make return type explicit.
-    mathmlBuilder?: (group: ParseNode<NODETYPE>, options: Options) => *,
+    mathmlBuilder?: (
+        group: ParseNode<NODETYPE>,
+        options: Options,
+    ) => MathNode | TextNode | domTree.documentFragment,
 |};
 
 /**

--- a/src/defineFunction.js
+++ b/src/defineFunction.js
@@ -108,6 +108,8 @@ type FunctionDefSpec<NODETYPE: NodeType> = {|
     // created when rendering the defined LaTeX function.
     htmlBuilder?: (group: ParseNode<NODETYPE>, options: Options) => HtmlDomNode,
 
+    // TODO: Currently functions/op.js returns documentFragment. Refactor it
+    // and update the return type of this function.
     // This function returns an object representing the MathML structure to be
     // created when rendering the defined LaTeX function.
     mathmlBuilder?: (

--- a/src/functions/op.js
+++ b/src/functions/op.js
@@ -216,6 +216,10 @@ const mathmlBuilder = (group, options) => {
         const operator = new mathMLTree.MathNode("mo",
             [mml.makeText("\u2061", "text")]);
 
+        // TODO: Refactor to not return an HTML DOM object from MathML builder
+        // or refactor documentFragment to be standalone and explicitly reusable
+        // for both HTML and MathML DOM operations. In either case, update the
+        // return type of `mathBuilder` in `defineFunction` to accommodate.
         return new domTree.documentFragment([node, operator]);
     }
 

--- a/src/mathMLTree.js
+++ b/src/mathMLTree.js
@@ -29,7 +29,7 @@ export type MathNodeType =
  * constructor requires the type of node to create (for example, `"mo"` or
  * `"mspace"`, corresponding to `<mo>` and `<mspace>` tags).
  */
-class MathNode {
+export class MathNode {
     type: MathNodeType;
     attributes: {[string]: string};
     children: (MathNode | TextNode)[];
@@ -114,7 +114,7 @@ class MathNode {
 /**
  * This node represents a piece of text.
  */
-class TextNode {
+export class TextNode {
     text: string;
 
     constructor(text: string) {


### PR DESCRIPTION
This is extremely trivial (no logic change or new assertions), and could actually have been done as part of the previous PR. It's useful to have this in before moving things into functions/* as the new additions are more strongly type-checked by this.