### PR TITLE
Cleanup MathML <mrow>, <mtext>, <mn>

### DIFF
--- a/src/buildMathML.js
+++ b/src/buildMathML.js
@@ -162,18 +162,24 @@ groupTypes.tag = function(group, options) {
  */
 export const buildExpression = function(expression, options) {
     const groups = [];
-    let currentText = null;
+    let lastGroup;
     for (let i = 0; i < expression.length; i++) {
         const group = buildGroup(expression[i], options);
-        if (group.type === 'mtext' && currentText !== null) {
-            currentText.children.push(...group.children);
+        // Concatenate adjacent <mtext>s
+        if (group.type === 'mtext' && lastGroup && lastGroup.type === 'mtext') {
+            lastGroup.children.push(...group.children);
+        // Concatenate adjacent <mn>s
+        } else if (group.type === 'mn' &&
+                   lastGroup && lastGroup.type === 'mn') {
+            lastGroup.children.push(...group.children);
+        // Concatenate <mn>...</mn> followed by <mi>.</mi>
+        } else if (group.type === 'mi' && group.children.length === 1 &&
+                   group.children[0].text === '.' &&
+                   lastGroup && lastGroup.type === 'mn') {
+            lastGroup.children.push(...group.children);
         } else {
             groups.push(group);
-            if (group.type === 'mtext') {
-                currentText = group;
-            } else {
-                currentText = null;
-            }
+            lastGroup = group;
         }
     }
 

--- a/src/functions/delimsizing.js
+++ b/src/functions/delimsizing.js
@@ -261,9 +261,7 @@ defineFunction({
             inner.push(rightNode);
         }
 
-        const outerNode = new mathMLTree.MathNode("mrow", inner);
-
-        return outerNode;
+        return mml.makeRow(inner);
     },
 });
 

--- a/src/functions/genfrac.js
+++ b/src/functions/genfrac.js
@@ -243,9 +243,7 @@ defineFunction({
                 withDelims.push(rightOp);
             }
 
-            const outerNode = new mathMLTree.MathNode("mrow", withDelims);
-
-            return outerNode;
+            return mml.makeRow(withDelims);
         }
 
         return node;

--- a/src/functions/href.js
+++ b/src/functions/href.js
@@ -1,7 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
 import buildCommon from "../buildCommon";
-import mathMLTree from "../mathMLTree";
 import {assertNodeType} from "../ParseNode";
 
 import * as html from "../buildHTML";
@@ -35,8 +34,7 @@ defineFunction({
         return new buildCommon.makeAnchor(href, [], elements, options);
     },
     mathmlBuilder: (group, options) => {
-        const inner = mml.buildExpression(group.value.body, options);
-        const math = new mathMLTree.MathNode("mrow", inner);
+        const math = mml.buildExpressionRow(group.value.body, options);
         math.setAttribute("href", group.value.href);
         return math;
     },

--- a/src/functions/mathchoice.js
+++ b/src/functions/mathchoice.js
@@ -1,7 +1,6 @@
 // @flow
 import defineFunction, {ordargument} from "../defineFunction";
 import buildCommon from "../buildCommon";
-import mathMLTree from "../mathMLTree";
 import Style from "../Style";
 import * as html from "../buildHTML";
 import * as mml from "../buildMathML";
@@ -47,11 +46,6 @@ defineFunction({
     },
     mathmlBuilder: (group, options) => {
         const body = chooseMathStyle(group, options);
-        const elements = mml.buildExpression(
-            body,
-            options,
-            false
-        );
-        return new mathMLTree.MathNode("mrow", elements);
+        return mml.buildExpressionRow(body, options);
     },
 });

--- a/src/functions/text.js
+++ b/src/functions/text.js
@@ -62,6 +62,6 @@ defineFunction({
         return buildCommon.makeSpan(["mord", "text"], inner, newOptions);
     },
     mathmlBuilder(group, options) {
-        return mml.makeTextRow(group.value.body, options);
+        return mml.buildExpressionRow(group.value.body, options);
     },
 });

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -87,11 +87,9 @@ exports[`A MathML builder should generate the right types of nodes 1`] = `
       <mo>
         ⁡
       </mo>
-      <mrow>
-        <mi>
-          x
-        </mi>
-      </mrow>
+      <mi>
+        x
+      </mi>
       <mo>
         +
       </mo>
@@ -339,11 +337,9 @@ exports[`A MathML builder should render mathchoice as if there was nothing 3`] =
         <mi>
           x
         </mi>
-        <mrow>
-          <mi>
-            T
-          </mi>
-        </mrow>
+        <mi>
+          T
+        </mi>
       </msub>
     </mrow>
     <annotation encoding="application/x-tex">
@@ -367,11 +363,9 @@ exports[`A MathML builder should render mathchoice as if there was nothing 4`] =
           <mi>
             y
           </mi>
-          <mrow>
-            <mi>
-              T
-            </mi>
-          </mrow>
+          <mi>
+            T
+          </mi>
         </msub>
       </msub>
     </mrow>
@@ -387,8 +381,8 @@ exports[`A MathML builder should set href attribute for href appropriately 1`] =
 
 <math>
   <semantics>
-    <mrow href="http://example.org">
-      <mi>
+    <mrow>
+      <mi href="http://example.org">
         α
       </mi>
     </mrow>
@@ -406,11 +400,9 @@ exports[`A MathML builder should use <menclose> for colorbox 1`] = `
   <semantics>
     <mrow>
       <menclose mathbackground="red">
-        <mrow>
-          <mtext>
-            b
-          </mtext>
-        </mrow>
+        <mtext>
+          b
+        </mtext>
       </menclose>
     </mrow>
     <annotation encoding="application/x-tex">
@@ -427,11 +419,9 @@ exports[`A MathML builder should use <mpadded> for raisebox 1`] = `
   <semantics>
     <mrow>
       <mpadded voffset="0.25em">
-        <mrow>
-          <mtext>
-            b
-          </mtext>
-        </mrow>
+        <mtext>
+          b
+        </mtext>
       </mpadded>
     </mrow>
     <annotation encoding="application/x-tex">

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -110,6 +110,35 @@ exports[`A MathML builder should generate the right types of nodes 1`] = `
 
 `;
 
+exports[`A MathML builder should generate the right types of nodes 2`] = `
+
+<math>
+  <semantics>
+    <mrow>
+      <mi>
+        sin
+      </mi>
+      <mo>
+        ⁡
+      </mo>
+      <mi>
+        α
+      </mi>
+      <mo>
+        =
+      </mo>
+      <mn>
+        0.34
+      </mn>
+    </mrow>
+    <annotation encoding="application/x-tex">
+      \\sin{\\alpha}=0.34
+    </annotation>
+  </semantics>
+</math>
+
+`;
+
 exports[`A MathML builder should make prime operators into <mo> nodes 1`] = `
 
 <math>

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -57,6 +57,35 @@ exports[`A MathML builder accents turn into <mover accent="true"> in MathML 1`] 
 
 `;
 
+exports[`A MathML builder should concatenate digits into single <mn> 1`] = `
+
+<math>
+  <semantics>
+    <mrow>
+      <mi>
+        sin
+      </mi>
+      <mo>
+        ⁡
+      </mo>
+      <mi>
+        α
+      </mi>
+      <mo>
+        =
+      </mo>
+      <mn>
+        0.34
+      </mn>
+    </mrow>
+    <annotation encoding="application/x-tex">
+      \\sin{\\alpha}=0.34
+    </annotation>
+  </semantics>
+</math>
+
+`;
+
 exports[`A MathML builder should generate <mphantom> nodes for \\phantom 1`] = `
 
 <math>
@@ -104,35 +133,6 @@ exports[`A MathML builder should generate the right types of nodes 1`] = `
     </mrow>
     <annotation encoding="application/x-tex">
       \\sin{x}+1\\;\\text{a}
-    </annotation>
-  </semantics>
-</math>
-
-`;
-
-exports[`A MathML builder should generate the right types of nodes 2`] = `
-
-<math>
-  <semantics>
-    <mrow>
-      <mi>
-        sin
-      </mi>
-      <mo>
-        ⁡
-      </mo>
-      <mi>
-        α
-      </mi>
-      <mo>
-        =
-      </mo>
-      <mn>
-        0.34
-      </mn>
-    </mrow>
-    <annotation encoding="application/x-tex">
-      \\sin{\\alpha}=0.34
     </annotation>
   </semantics>
 </math>

--- a/test/__snapshots__/mathml-spec.js.snap
+++ b/test/__snapshots__/mathml-spec.js.snap
@@ -497,22 +497,9 @@ exports[`A MathML builder tags use <mlabeledtr> 1`] = `
     <mtable side="right">
       <mlabeledtr>
         <mtd>
-          <mrow>
-            <mtext>
-              (
-            </mtext>
-            <mrow>
-              <mtext>
-                h
-              </mtext>
-              <mtext>
-                i
-              </mtext>
-            </mrow>
-            <mtext>
-              )
-            </mtext>
-          </mrow>
+          <mtext>
+            (hi)
+          </mtext>
         </mtd>
         <mtd>
           <mrow>

--- a/test/mathml-spec.js
+++ b/test/mathml-spec.js
@@ -35,6 +35,10 @@ describe("A MathML builder", function() {
         expect(getMathML("\\sin{x}+1\\;\\text{a}")).toMatchSnapshot();
     });
 
+    it('should concatenate digits into single <mn>', () => {
+        expect(getMathML("\\sin{\\alpha}=0.34")).toMatchSnapshot();
+    });
+
     it('should make prime operators into <mo> nodes', () => {
         expect(getMathML("f'")).toMatchSnapshot();
     });


### PR DESCRIPTION
* Avoid unnecessary `<mrow>` wrapping (fix #880)
* buildMathML gains two helpers:
    * `makeRow` helper wraps an array of nodes in `<mrow>`, unless the array has length 1, in which case no wrapping is necessary.
    * `buildExpressionRow` for common case of `makeRow(buildExpression(...))`
* Combine adjacent `<mtext>`s in all cases, not just immediately within `\text`.
   * No more need for `makeTextRow` helper or anything fancy in text MathML handler.
* Concatenate `<mn>`s and decimal point into single `<mn>` (fix #203)