### PR TITLE
Enable output modules to be used in browser or Node

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -57,6 +57,9 @@ function createConfig(target /*: Target */, dev /*: boolean */,
             library: target.library,
             libraryTarget: 'umd',
             libraryExport: 'default',
+            // Enable output modules to be used in browser or Node.
+            // See: https://github.com/webpack/webpack/issues/6522
+            globalObject: "typeof self !== 'undefined' ? self : this",
             path: path.resolve(__dirname, 'build'),
             publicPath: dev ? '/' : '',
         },


### PR DESCRIPTION
This makes cli.js work again from the Node command line; see https://github.com/Khan/KaTeX/issues/894#issuecomment-393962739.

Workaround for bug reported in https://github.com/webpack/webpack/issues/6522