### PR TITLE
Edit \lbrack and \rbrack

### DIFF
--- a/src/delimiter.js
+++ b/src/delimiter.js
@@ -219,12 +219,12 @@ const makeStackedDelim = function(
         top = "\\Uparrow";
         repeat = "\u2016";
         bottom = "\\Downarrow";
-    } else if (delim === "[") {
+    } else if (delim === "[" || delim === "\\lbrack") {
         top = "\u23a1";
         repeat = "\u23a2";
         bottom = "\u23a3";
         font = "Size4-Regular";
-    } else if (delim === "]") {
+    } else if (delim === "]" || delim === "\\rbrack") {
         top = "\u23a4";
         repeat = "\u23a5";
         bottom = "\u23a6";
@@ -480,7 +480,7 @@ const makeSqrtImage = function(
 // There are three kinds of delimiters, delimiters that stack when they become
 // too large
 const stackLargeDelimiters = [
-    "(", ")", "[", "]",
+    "(", ")", "[", "\\lbrack", "]", "\\rbrack",
     "\\{", "\\lbrace", "\\}", "\\rbrace",
     "\\lfloor", "\\rfloor", "\u230a", "\u230b",
     "\\lceil", "\\rceil", "\u2308", "\u2309",

--- a/src/functions/delimsizing.js
+++ b/src/functions/delimsizing.js
@@ -36,7 +36,7 @@ const delimiterSizes = {
 };
 
 const delimiters = [
-    "(", ")", "[", "]",
+    "(", ")", "[", "\\lbrack", "]", "\\rbrack",
     "\\{", "\\lbrace", "\\}", "\\rbrace",
     "\\lfloor", "\\rfloor", "\u230a", "\u230b",
     "\\lceil", "\\rceil", "\u2308", "\u2309",

--- a/src/macros.js
+++ b/src/macros.js
@@ -244,14 +244,10 @@ defineMacro("\\endgroup", "}");
 // Symbols from latex.ltx:
 // \def\lq{`}
 // \def\rq{'}
-// \def\lbrack{[}
-// \def\rbrack{]}
 // \def \aa {\r a}
 // \def \AA {\r A}
 defineMacro("\\lq", "`");
 defineMacro("\\rq", "'");
-defineMacro("\\lbrack", "[");
-defineMacro("\\rbrack", "]");
 defineMacro("\\aa", "\\r a");
 defineMacro("\\AA", "\\r A");
 

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -617,7 +617,9 @@ defineSymbol(text, main, textord, "}", "\\textbraceright");
 defineSymbol(math, main, open, "{", "\\lbrace");
 defineSymbol(math, main, close, "}", "\\rbrace");
 defineSymbol(math, main, open, "[", "\\lbrack");
+defineSymbol(text, main, textord, "[", "\\lbrack");
 defineSymbol(math, main, close, "]", "\\rbrack");
+defineSymbol(text, main, textord, "]", "\\rbrack");
 defineSymbol(text, main, textord, "<", "\\textless"); // in T1 fontenc
 defineSymbol(text, main, textord, ">", "\\textgreater"); // in T1 fontenc
 defineSymbol(math, main, open, "\u230a", "\\lfloor", true);


### PR DESCRIPTION
This PR revisits the redundant code for `\lbrack` and `\rbrack`.  It reverts the code in `delimisizing.js` and `delimiter.js`, removes the macros, and adds text-mode symbols to `symbols.js`.I believe that this captures the sense of yesterday's conversation. 

Below is visual evidence for math mode, text mode, `\big`, and `\left` operating on `[`, `]`, `\lbrack` and `\rbrack`.

![brack](https://user-images.githubusercontent.com/16403058/41203133-e2272278-6c87-11e8-927b-78d444d3c9d8.PNG)