### PR TITLE
Update gh-pages to 0.10.0-beta

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <meta property="og:url" content="http://khan.github.io/KaTeX/">
     <meta property="og:image" content="http://khan.github.io/KaTeX/og_logo.png">
     <meta property="og:description" content="Simple API, no dependencies – yet super-fast on all major browsers.">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-alpha/dist/katex.min.css" integrity="sha384-BTL0nVi8DnMrNdMQZG1Ww6yasK9ZGnUxL1ZWukXQ7fygA1py52yPp9W4wrR00VML" crossorigin="anonymous">
-    <script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-alpha/dist/katex.min.js"  integrity="sha384-y6SGsNt7yZECc4Pf86XmQhC4hG2wxL6Upkt9N1efhFxfh6wlxBH0mJiTE8XYclC1" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" integrity="sha384-9tPv11A+glH/on/wEu99NVwDPwkMQESOocs/ZGXPoIiLE8MU/qkqUcZ3zzL+6DuH" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js" integrity="sha384-U8Vrjwb8fuHMt6ewaCy8uqeUXv4oitYACKdB0VziCerzt011iQ/0TqlSlv8MReCm" crossorigin="anonymous"></script>
     <link href="bower_components/normalize.css/normalize.css" type="text/css" rel="stylesheet">
     <link href="bower_components/font-awesome/css/font-awesome.min.css" type="text/css" rel="stylesheet">
     <link href="main.css" type="text/css" rel="stylesheet">


### PR DESCRIPTION
Customary PR to bring `gh-pages` branch to latest release (just the `index.html` demo, not the `function-support.html` which waits for @ronkok's PR).  We might consider making this part of the release script too (if we allow direct pushing to `gh-pages` by release maintainers).