### PR TITLE
Support \gdef in multiple equations in auto-render

### DIFF
--- a/contrib/auto-render/README.md
+++ b/contrib/auto-render/README.md
@@ -91,6 +91,10 @@ in addition to two auto-render-specific keys:
 - `errorCallback`: A callback method returning a message and an error stack
   in case of an critical error during rendering. The default uses `console.error`.
 
-Note that the `displayMode` property of the options object is ignored, and is
+The `displayMode` property of the options object is ignored, and is
 instead taken from the `display` key of the corresponding entry in the
 `delimiters` key.
+
+The same `options.macros` object (which defaults to an empty object `{}`)
+is passed into several calls to `katex.render`, so that consecutive equations
+can build up shared macros by `\gdef`.

--- a/contrib/auto-render/auto-render.js
+++ b/contrib/auto-render/auto-render.js
@@ -101,6 +101,13 @@ const renderMathInElement = function(elem, options) {
     }
 
     const optionsCopy = Object.assign({}, defaultAutoRenderOptions, options);
+
+    // Enable sharing of global macros defined via `\gdef` between different
+    // math elements within a single call to `renderMathInElement`.
+    if (!optionsCopy.macros) {
+        optionsCopy.macros = {};
+    }
+
     renderElem(elem, optionsCopy);
 };
 


### PR DESCRIPTION
Within a single call to `renderMathInElement`, default `macros` to a shared empty object (same as if you specified an object) so that global macros defined via `\gdef` can be defined and shared.

As discussed in https://github.com/Khan/KaTeX/pull/1348#issuecomment-396672064