### PR TITLE
Fix Webpack global function definition, including hot module replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^4.9.1",
     "webpack-bundle-analyzer": "^2.13.0",
-    "webpack-cli": "^3.0.0",
+    "webpack-cli": "^3.0.1",
     "webpack-dev-server": "^3.1.4"
   },
   "bin": "cli.js",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -59,7 +59,7 @@ function createConfig(target /*: Target */, dev /*: boolean */,
             libraryExport: 'default',
             // Enable output modules to be used in browser or Node.
             // See: https://github.com/webpack/webpack/issues/6522
-            globalObject: "typeof self !== 'undefined' ? self : this",
+            globalObject: "(typeof self !== 'undefined' ? self : this)",
             path: path.resolve(__dirname, 'build'),
             publicPath: dev ? '/' : '',
         },


### PR DESCRIPTION
Changing `globalObject` to an expression as a workaround in #1401 resulted in codes like `typeof self !== 'undefined' ? self : this["webpackHotUpdatekatex"] =`, which breaks global function definition such as HMR, due to operator precedence.