### PR TITLE
Expose dom tree

### DIFF
--- a/katex.js
+++ b/katex.js
@@ -190,7 +190,7 @@ export default {
      */
     __defineMacro: defineMacro,
     /**
-     * Exposes the dom tree, which can be useful for type checking against nodes.
+     * Expose the dom tree node types, which can be useful for type checking nodes.
      *
      * NOTE: This method is not currently recommended for public use.
      * The internal tree representation is unstable and is very likely

--- a/katex.js
+++ b/katex.js
@@ -191,6 +191,10 @@ export default {
     __defineMacro: defineMacro,
     /**
      * Exposes the dom tree, which can be useful for type checking against nodes.
+     *
+     * NOTE: This method is not currently recommended for public use.
+     * The internal tree representation is unstable and is very likely
+     * to change. Use at your own risk.
      */
     __domTree: domTree,
 };

--- a/katex.js
+++ b/katex.js
@@ -189,4 +189,8 @@ export default {
      * adds a new macro to builtin macro list
      */
     __defineMacro: defineMacro,
+    /**
+     * Exposes the dom tree, which can be useful for type checking against nodes.
+     */
+    __domTree: domTree,
 };


### PR DESCRIPTION
A simple solution for type checking dom nodes. This is a followup to the discussion found here: https://github.com/Khan/KaTeX/issues/1439