### PR TITLE
Support Unicode corners

### DIFF
--- a/src/macros.js
+++ b/src/macros.js
@@ -320,6 +320,10 @@ defineMacro("\u225F", "\\stackrel{\\tiny?}{=}");
 defineMacro("\u27C2", "\\perp");
 defineMacro("\u203C", "\\mathclose{!\\mkern-0.8mu!}");
 defineMacro("\u220C", "\\notni");
+defineMacro("\u231C", "\\ulcorner");
+defineMacro("\u231D", "\\urcorner");
+defineMacro("\u231E", "\\llcorner");
+defineMacro("\u231F", "\\urcorner");
 
 //////////////////////////////////////////////////////////////////////
 // LaTeX_2ε

--- a/src/macros.js
+++ b/src/macros.js
@@ -323,7 +323,7 @@ defineMacro("\u220C", "\\notni");
 defineMacro("\u231C", "\\ulcorner");
 defineMacro("\u231D", "\\urcorner");
 defineMacro("\u231E", "\\llcorner");
-defineMacro("\u231F", "\\urcorner");
+defineMacro("\u231F", "\\lrcorner");
 
 //////////////////////////////////////////////////////////////////////
 // LaTeX_2ε

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3064,6 +3064,7 @@ describe("Unicode", function() {
         expect("\\left\u27e8\\frac{a}{b}\\right\u27e9").toBuild();
         expect("\\left\u23b0\\frac{a}{b}\\right\u23b1").toBuild();
         expect("┌x┐ └x┘").toBuild();
+        expect("\u231Cx\u231D \u231Ex\u231F").toBuild();
     });
 
     it("should build some surrogate pairs", function() {


### PR DESCRIPTION
In the KaTeX fonts, the `⌜` `⌝` `⌞` `⌟` characters, for the AMS functions `\ulcorner`, `\urcorner`, `\llcorner`, and `\lrcorner` respectively, are located at the Unicode code points for Box Drawings corners. In contrast, `unicode-math` maps those functions to Unicode code points U+231C - U+231F. The names of those code points are Top Left Corner, Top Right Corner, etc, in the Unicode Miscellaneous Technical block. `unicode-math` doesn't map the Box Drawing corners to anything at all.

This PR adds support for U+231C through U+231F.