### PR TITLE
Remove tree cloning before building HTML

### DIFF
--- a/src/buildHTML.js
+++ b/src/buildHTML.js
@@ -318,10 +318,6 @@ function buildHTMLUnbreakable(children, options) {
  * nodes.
  */
 export default function buildHTML(tree: AnyParseNode[], options: Options): DomSpan {
-    // buildExpression is destructive, so we need to make a clone
-    // of the incoming tree so that it isn't accidentally changed
-    tree = JSON.parse(JSON.stringify(tree));
-
     // Strip off outer tag wrapper for processing below.
     let tag = null;
     if (tree.length === 1 && tree[0].type === "tag") {

--- a/src/buildTree.js
+++ b/src/buildTree.js
@@ -22,8 +22,6 @@ export const buildTree = function(
     settings: Settings,
 ): DomSpan {
     const options = optionsFromSettings(settings);
-    // `buildHTML` sometimes messes with the parse tree (like turning bins ->
-    // ords), so we build the MathML version first.
     const mathMLNode = buildMathML(tree, expression, options);
     const htmlNode = buildHTML(tree, options);
 

--- a/src/defineFunction.js
+++ b/src/defineFunction.js
@@ -116,12 +116,14 @@ type FunctionDefSpec<NODETYPE: NodeType> = {|
 
     // This function returns an object representing the DOM structure to be
     // created when rendering the defined LaTeX function.
+    // This should not modify the `ParseNode`.
     htmlBuilder?: HtmlBuilder<NODETYPE>,
 
     // TODO: Currently functions/op.js returns documentFragment. Refactor it
     // and update the return type of this function.
     // This function returns an object representing the MathML structure to be
     // created when rendering the defined LaTeX function.
+    // This should not modify the `ParseNode`.
     mathmlBuilder?: MathMLBuilder<NODETYPE>,
 |};
 

--- a/src/functions/accent.js
+++ b/src/functions/accent.js
@@ -41,6 +41,9 @@ export const htmlBuilder: HtmlBuilderSupSub<"accent"> = (grp, options) => {
         // Rerender the supsub group with its new base, and store that
         // result.
         supSubGroup = assertDomContainer(html.buildGroup(supSub, options));
+
+        // reset original base
+        supSub.value.base = group;
     } else {
         group = assertNodeType(grp, "accent");
         base = group.value.base;


### PR DESCRIPTION
Related #225.

The only place where tree is mutated was `accent`.

This also removes `JSON.stringify()` polyfill, which is about 2KB. (#1469)