### PR TITLE
AsciiMath: link to asciimath2tex

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ will appear larger than 1cm in browser units.
 
 - [katex-ruby](https://github.com/glebm/katex-ruby) Provides server-side rendering and integration with popular Ruby web frameworks (Rails, Hanami, and anything that uses Sprockets).
 
+### AsciiMath
+
+If you want to render math written in [AsciiMath](http://asciimath.org/),
+you'll need to first convert AsciiMath into LaTeX input, then call KaTeX.
+
+- [asciimath2tex](https://github.com/christianp/asciimath2tex)
+  converts AsciiMath to TeX, with KaTeX in mind
 
 ## Contributing
 


### PR DESCRIPTION
I don't think we plan to add AsciiMath input directly to KaTeX, but luckily there's a library that converts AsciiMath to TeX, designed for KaTeX!  See #1472.

This PR adds a link to the README.  I wasn't sure on the exact ordering, though I think Libraries is the right section.