### PR TITLE
Screenshotter chdir to KaTeX root directory

### DIFF
--- a/dockers/Screenshotter/screenshotter.js
+++ b/dockers/Screenshotter/screenshotter.js
@@ -19,7 +19,7 @@ const data = require("../../test/screenshotter/ss_data");
 
 // Change to KaTeX root directory so that webpack (in particular
 // babel-plugin-version-inline) runs correctly.
-process.chdir(path.join(__dirname, "..", ".."))
+process.chdir(path.join(__dirname, "..", ".."));
 const dstDir = path.normalize(path.join("test", "screenshotter", "images"));
 const diffDir = path.normalize(path.join("test", "screenshotter", "diff"));
 const newDir = path.normalize(path.join("test", "screenshotter", "new"));

--- a/dockers/Screenshotter/screenshotter.js
+++ b/dockers/Screenshotter/screenshotter.js
@@ -17,12 +17,12 @@ const webpackDevServer = require("webpack-dev-server");
 const webpackConfig = require("../../webpack.dev");
 const data = require("../../test/screenshotter/ss_data");
 
-const dstDir = path.normalize(
-    path.join(__dirname, "..", "..", "test", "screenshotter", "images"));
-const diffDir = path.normalize(
-    path.join(__dirname, "..", "..", "test", "screenshotter", "diff"));
-const newDir = path.normalize(
-    path.join(__dirname, "..", "..", "test", "screenshotter", "new"));
+// Change to KaTeX root directory so that webpack (in particular
+// babel-plugin-version-inline) runs correctly.
+process.chdir(path.join(__dirname, "..", ".."))
+const dstDir = path.normalize(path.join("test", "screenshotter", "images"));
+const diffDir = path.normalize(path.join("test", "screenshotter", "diff"));
+const newDir = path.normalize(path.join("test", "screenshotter", "new"));
 
 //////////////////////////////////////////////////////////////////////
 // Process command line arguments


### PR DESCRIPTION
Fix #1501.  This seems to be required for webpack, specifically `babel-plugin-version-inline`, to run correctly.