### PR TITLE
Set baseUrl depending on the environment

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -8,6 +8,10 @@
 // See https://docusaurus.io/docs/site-config.html for all the possible
 // site configuration options.
 
+// If BASE_URL environment variable is set, use it as baseUrl.
+// If on netlify, use '/'. Otherwise use '/KaTeX/'.
+const baseUrl = process.env.BASE_URL || (process.env.CONTEXT ? '/' : '/KaTeX/');
+
 /* List of projects/orgs using your project for the users page */
 const users = [
     {
@@ -22,7 +26,7 @@ const siteConfig = {
     title: 'KaTeX',
     tagline: 'The fastest math typesetting library for the web',
     url: 'https://khan.github.io',
-    baseUrl: '/KaTeX/',
+    baseUrl,
 
     // Used for publishing and more
     projectName: 'KaTeX',


### PR DESCRIPTION
Fixes partly #1525.

* If `BASE_URL` environment variable is set, it takes precedence
  * e.g., `BASE_URL=/ npm start`
* If on [netlify](https://www.netlify.com/), it is set to `/`
  * Detects by the presence of [`CONTEXT` environment variable](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables), chosen it as it seems unique to netlify
  * Tested on https://practical-pare-ca0ab7.netlify.com/
* Otherwise, use `/KaTeX/`