### PR TITLE
Replace `yarn run` and `yarn install` with `yarn`, remove building with `npm` instructions

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -2,7 +2,7 @@
   "linters": {
     "katex-linter": {
       "type": "script-and-regex",
-      "script-and-regex.script": "yarn run test:lint || true",
+      "script-and-regex.script": "yarn test:lint || true",
       "script-and-regex.regex": "/^(?P<file>\\S+): line (?P<line>\\d+), col \\d+, (?P<message>.*)$/m"
     }
   }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
 
       - run:
           name: Build KaTeX
-          command: yarn run build
+          command: yarn build
 
       - store_artifacts:
           path: dist/katex.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ restore_node_modules_cache: &restore_node_modules_cache
 yarn_install: &yarn_install
   run:
     name: Install dependencies
-    command: yarn install
+    command: yarn
 
 screenshotter: &screenshotter
   steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ single file.  The goal is to have all functions use this new system.
 ## Testing
 
 Local testing can be done by running the webpack-dev-server using configuration
-`webpack.dev.js`. Run `yarn install` to install dependencies, and then `yarn start`
+`webpack.dev.js`. Run `yarn` to install dependencies, and then `yarn start`
 to start the server.
 
 This will host an interactive editor at
@@ -160,7 +160,7 @@ Flow by running `yarn test:flow`. See [Flow](https://flow.org/) for more details
 The fonts for KaTeX live in a submodule stored in `submodules/katex-fonts`.
 When you first clone the KaTeX repository, use
 `git submodule update --init --recursive` to download the corresponding
-fonts repository.  After running `yarn install`, you should have Git hooks that
+fonts repository.  After running `yarn`, you should have Git hooks that
 will automatically run this command after switching to branches
 where `submodules/katex-fonts` point to different commits.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ by running `yarn add webpack-dev-server@2.7.1`.
 
 The JavaScript parser and some of the HTML and MathML tree
 builders are tested with Jest. These tests can be run using node with
-`yarn run test:jest`.  If you need to debug the tests see
+`yarn test:jest`.  If you need to debug the tests see
 [https://facebook.github.io/jest/docs/troubleshooting.html](https://facebook.github.io/jest/docs/troubleshooting.html)
 
 The interactive editor can also be used for debugging tests in the browser by
@@ -88,9 +88,9 @@ tests when you submit a pull request, in case you forget.
 If you make any changes to Parser.js, add Jest tests to ensure they work.
 
 Some tests verify the structure of the output tree using [snapshot testing](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
-Those snapshots can be updated by running `yarn run test:jest:update`.
+Those snapshots can be updated by running `yarn test:jest:update`.
 
-Also, test code coverage can be collected by `yarn run test:jest:coverage`.
+Also, test code coverage can be collected by `yarn test:jest:coverage`.
 You can view the report in `coverage/lcov-report/index.html`.
 
 #### Screenshot tests
@@ -126,7 +126,7 @@ try to test in IE 9, using [modern.ie](http://modern.ie) VMs.
 ## Building
 
 KaTeX is built using webpack with configuration `webpack.config.js`. Run
-`yarn run build` to build the project.
+`yarn build` to build the project.
 
 ## Style guide
 
@@ -141,12 +141,12 @@ Code
 
 In general, try to make your code blend in with the surrounding code.
 
-The code can be linted by running `yarn run test:lint`, which lints JavaScript
+The code can be linted by running `yarn test:lint`, which lints JavaScript
 files using ESLint and stylesheets using stylelint. They must pass to commit
 the changes.
 
 Some files have flowtype annotations and can be checked for type errors using
-Flow by running `yarn run test:flow`. See [Flow](https://flow.org/) for more details.
+Flow by running `yarn test:flow`. See [Flow](https://flow.org/) for more details.
 
 ## Pull Requests
 

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 // Simple CLI for KaTeX.
 // Reads TeX from stdin, outputs HTML to stdout.
 // To run this from the repository, you must first build KaTeX by running
-// `yarn install` and `yarn run build`.
+// `yarn install` and `yarn build`.
 
 /* eslint no-console:0 */
 
@@ -12,7 +12,7 @@ try {
 } catch (e) {
     console.error(
         "KaTeX could not import, likely because dist/katex.js is missing.");
-    console.error("Please run 'yarn install' and 'yarn run build' before running");
+    console.error("Please run 'yarn install' and 'yarn build' before running");
     console.error("cli.js from the KaTeX repository.");
     console.error();
     throw e;

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 // Simple CLI for KaTeX.
 // Reads TeX from stdin, outputs HTML to stdout.
 // To run this from the repository, you must first build KaTeX by running
-// `yarn install` and `yarn build`.
+// `yarn` and `yarn build`.
 
 /* eslint no-console:0 */
 
@@ -12,7 +12,7 @@ try {
 } catch (e) {
     console.error(
         "KaTeX could not import, likely because dist/katex.js is missing.");
-    console.error("Please run 'yarn install' and 'yarn build' before running");
+    console.error("Please run 'yarn' and 'yarn build' before running");
     console.error("cli.js from the KaTeX repository.");
     console.error();
     throw e;

--- a/dockers/Screenshotter/README.md
+++ b/dockers/Screenshotter/README.md
@@ -8,7 +8,7 @@ installed and running.
 If all you want is (re)create
 all the snapshots for all the browsers, then you can do so by:
 
-    yarn run test:screenshots:update
+    yarn test:screenshots:update
 
 It will fetch all required selenium docker images, and use them to
 take screenshots.
@@ -69,7 +69,7 @@ Examples:
 
 You can verify screenshots by running:
 
-    yarn run test:screenshots
+    yarn test:screenshots
 
 or passing `--verify` option to `screenshotter.js` or `screenshotter.sh`.
 See above for more details.

--- a/dockers/texcmp/README.md
+++ b/dockers/texcmp/README.md
@@ -30,7 +30,7 @@ the even larger overhead of setting up docker and creating the initial
 image, then you may instead execute the commands
 
     cd dockers/texcmp
-    yarn install
+    yarn
     node texcmp.js
 
 from the root of your KaTeX directory tree.  Required tools include the

--- a/docs/cli.md.template
+++ b/docs/cli.md.template
@@ -15,7 +15,7 @@ npx katex
 You can execute with the relative path: `./node_modules/.bin/katex`
 
 > To use CLI from local clone, you need to build the project first by
-running `yarn run build`.  See [Building from Source](node.md#building-from-source) 
+running `yarn build`.  See [Building from Source](node.md#building-from-source) 
 for more details.
 
 ## Options

--- a/docs/font.md
+++ b/docs/font.md
@@ -36,7 +36,7 @@ Based on this information and what you want to support with your website, you mi
 For example, if you wanted to create a trimmed down version of KaTeX, you could only include the `woff` files and gain the most support with the least number of files. To do this:
 
 1. Set `@use-ttf`, and `@use-woff2` to `false` at the top of [fonts.less](https://github.com/KaTeX/katex-fonts/blob/master/fonts.less).
-2. Rebuild KaTeX by running `yarn run build` from the top-level directory.
+2. Rebuild KaTeX by running `yarn build` from the top-level directory.
 3. Include only the `build/fonts/*.woff2` files in your distribution.
 
 ## Location of font files
@@ -44,5 +44,5 @@ For example, if you wanted to create a trimmed down version of KaTeX, you could 
 The default build of KaTeX expects the KaTeX fonts to be located in a directory called `fonts` which is a sibling of the `katex.min.css` stylesheet. This can be changed as such:
 
 1. At the top of the [fonts.less](https://github.com/KaTeX/katex-fonts/blob/master/fonts.less) file, set `@font-folder` to the location of your fonts. You can use relative or absolute paths, so setting it to `"/fonts"` would cause it to search for the fonts in a root `fonts` folder, while `"../fonts"` would search in a `fonts` directory one level above the `katex.min.css` file.
-2. Rebuild KaTeX by running `yarn run build` from the top-level directory.
+2. Rebuild KaTeX by running `yarn build` from the top-level directory.
 3. Use the newly generated `build/katex.min.css` file, and place the fonts where you indicated.

--- a/docs/node.md
+++ b/docs/node.md
@@ -22,7 +22,7 @@ yarn global add katex
 
 ## Building from Source
 
-To build you will need Git, Node.js 6.9 or later, and npm or Yarn.
+To build you will need Git, Node.js 6.9 or later, and Yarn(recommended) or npm.
 
 Clone a copy of the GitHub source repository:
 ```bash
@@ -32,8 +32,8 @@ cd KaTeX
 
 Then install dependencies and run `build` script:
 ```bash
-npm install # or yarn
-npm run build # or yarn build
+yarn # or npm install
+yarn build # or npm run build
 ```
 <br>
 > You can manually download the package and source code from

--- a/docs/node.md
+++ b/docs/node.md
@@ -32,7 +32,7 @@ cd KaTeX
 
 Then install dependencies and run `build` script:
 ```bash
-npm install # or yarn install
+npm install # or yarn
 npm run build # or yarn build
 ```
 <br>

--- a/docs/node.md
+++ b/docs/node.md
@@ -22,7 +22,7 @@ yarn global add katex
 
 ## Building from Source
 
-To build you will need Git, Node.js 6.9 or later, and Yarn(recommended) or npm.
+To build you will need Git, Node.js 6.9 or later, and Yarn.
 
 Clone a copy of the GitHub source repository:
 ```bash
@@ -32,8 +32,8 @@ cd KaTeX
 
 Then install dependencies and run `build` script:
 ```bash
-yarn # or npm install
-yarn build # or npm run build
+yarn
+yarn build
 ```
 <br>
 > You can manually download the package and source code from

--- a/package.json
+++ b/package.json
@@ -62,24 +62,24 @@
   },
   "bin": "cli.js",
   "scripts": {
-    "test": "yarn run prestart && yarn run test:lint && yarn run test:flow && yarn run test:jest",
+    "test": "yarn prestart && yarn test:lint && yarn test:flow && yarn test:jest",
     "test:lint": "eslint katex.js katex.webpack.js cli.js webpack.*.js src static test contrib dockers website && stylelint src/katex.less",
     "test:flow": "flow",
     "test:jest": "jest",
     "test:jest:watch": "jest --watch",
     "test:jest:update": "jest --updateSnapshot",
     "test:jest:coverage": "jest --coverage",
-    "test:screenshots": "yarn run test:screenshots:update --verify",
-    "test:screenshots:update": "yarn run prestart && dockers/Screenshotter/screenshotter.sh",
-    "test:perf": "yarn run prestart && NODE_ENV=test node test/perf-test.js",
+    "test:screenshots": "yarn test:screenshots:update --verify",
+    "test:screenshots:update": "yarn prestart && dockers/Screenshotter/screenshotter.sh",
+    "test:perf": "yarn prestart && NODE_ENV=test node test/perf-test.js",
     "clean": "rm -rf dist/ node_modules/",
-    "clean-install": "yarn run clean && yarn install",
+    "clean-install": "yarn clean && yarn install",
     "prestart": "node check-node-version.js && check-dependencies && node src/unicodeMake.js > src/unicodeSymbols.js",
     "start": "webpack-dev-server --hot --config webpack.dev.js",
     "analyze": "webpack --config webpack.analyze.js",
-    "build": "yarn run prestart && rimraf dist/ && mkdirp dist && cp README.md dist && webpack",
-    "watch": "yarn run build --watch",
-    "dist": "yarn test && yarn run build && yarn run dist:zip",
+    "build": "yarn prestart && rimraf dist/ && mkdirp dist && cp README.md dist && webpack",
+    "watch": "yarn build --watch",
+    "dist": "yarn test && yarn build && yarn dist:zip",
     "dist:zip": "cd dist && tar czf ../katex.tar.gz * && zip -rq ../katex.zip *"
   },
   "dependencies": {
@@ -87,7 +87,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run test:lint",
+      "pre-commit": "yarn test:lint",
       "post-merge": "git submodule update --init --recursive",
       "post-checkout": "git submodule update --init --recursive"
     }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "test:screenshots:update": "yarn prestart && dockers/Screenshotter/screenshotter.sh",
     "test:perf": "yarn prestart && NODE_ENV=test node test/perf-test.js",
     "clean": "rm -rf dist/ node_modules/",
-    "clean-install": "yarn clean && yarn install",
+    "clean-install": "yarn clean && yarn",
     "prestart": "node check-node-version.js && check-dependencies && node src/unicodeMake.js > src/unicodeSymbols.js",
     "start": "webpack-dev-server --hot --config webpack.dev.js",
     "analyze": "webpack --config webpack.analyze.js",

--- a/release.sh
+++ b/release.sh
@@ -106,7 +106,7 @@ rm -f package.json.bak
 
 # Build generated files and add them to the repository (for bower)
 git clean -fdx dist
-yarn run dist
+yarn dist
 sed -i.bak -E '/^\/dist\/$/d' .gitignore
 rm -f .gitignore.bak
 git add .gitignore dist/


### PR DESCRIPTION
* Replaced `yarn run ...` with `yarn ...`

From https://github.com/Khan/KaTeX/pull/1522#discussion_r205983374:
I thought only certain commands can pass through, but it seems every commands can pass through:

> It’s also possible to leave out the run in this command, each script can be executed with its name.
Note that built-in cli commands will have preference over your scripts, so you shouldn’t always rely on this shortcut in other scripts.

One place where our script may clash with built-in commands is `clean`, but Yarn won't be using it: https://github.com/yarnpkg/yarn/issues/2438.

* Replaced `yarn install` with `yarn`

> Default Command
Running yarn with no command will run `yarn install`, passing through any provided flags.

* Updated `node.md`: remove building with `npm` instructions, it's impossible to build without Yarn installed and for reproducible builds