### PR TITLE
 Comments without terminating newlines, \href fixes, \url support

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -18,6 +18,9 @@ You can provide an object of options as the last argument to `katex.render` and 
     incorrect (especially in terms of vertical heights).
   - `"unicodeTextInMathMode"`: Use of Unicode text characters in math mode.
   - `"mathVsTextUnits"`: Mismatch of math vs. text commands and units/mode.
+  - `"commentAtEnd"`: Use of `%` comment without a terminating newline.
+    LaTeX would thereby comment out the end of math mode (e.g. `$`),
+    causing an error.
   A second category of `errorCode`s never throw errors, but their strictness
   affects the behavior of KaTeX:
   - `"newLineInDisplayMode"`: Use of `\\` or `\newline` in display mode

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -86,7 +86,10 @@ The `{array}` environment does not yet support `\cline` or `\multicolumn`.
 
 ## HTML
 
-$\href{https://khan.github.io/KaTeX/}{KaTeX}$ `\href{https://khan.github.io/KaTeX/}{KaTeX}`
+||
+|:--------------------:|
+|$\href{https://khan.github.io/KaTeX/}{KaTeX}$ `\href{https://khan.github.io/KaTeX/}{KaTeX}`|
+|$\url{https://khan.github.io/KaTeX/}$ `\url{https://khan.github.io/KaTeX/}`|
 
 ## Letters and Unicode
 

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -86,10 +86,10 @@ The `{array}` environment does not yet support `\cline` or `\multicolumn`.
 
 ## HTML
 
-||
-|:--------------------:|
-|$\href{https://khan.github.io/KaTeX/}{KaTeX}$ `\href{https://khan.github.io/KaTeX/}{KaTeX}`|
-|$\url{https://khan.github.io/KaTeX/}$ `\url{https://khan.github.io/KaTeX/}`|
+|||
+|:----------------|:-------------------|
+| $\href{https://khan.github.io/KaTeX/}{KaTeX}$ | `\href{https://khan.github.io/KaTeX/}{KaTeX}` |
+| $\url{https://khan.github.io/KaTeX/}$ | `\url{https://khan.github.io/KaTeX/}` |
 
 ## Letters and Unicode
 

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -33,7 +33,7 @@ import type Settings from "./Settings";
  * If there is no matching function or symbol definition, the Parser will
  * still reject the input.
  */
-export const spaceRegexString = "[ \r\n\t]";
+const spaceRegexString = "[ \r\n\t]";
 const commentRegexString = "%[^\n]*(?:\n|$)";
 const controlWordRegexString = "\\\\[a-zA-Z@]+";
 const controlSymbolRegexString = "\\\\[^\uD800-\uDFFF]";

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -11,7 +11,7 @@ import unicodeSymbols from "./unicodeSymbols";
 import utils from "./utils";
 import ParseNode, {assertNodeType, checkNodeType} from "./ParseNode";
 import ParseError from "./ParseError";
-import {combiningDiacriticalMarksEndRegex} from "./Lexer.js";
+import {combiningDiacriticalMarksEndRegex, urlFunctionRegex} from "./Lexer.js";
 import Settings from "./Settings";
 import {Token} from "./Token";
 import type {AnyParseNode} from "./ParseNode";
@@ -660,7 +660,9 @@ export default class Parser {
             return this.parseSizeGroup(optional);
         }
         if (type === "url") {
-            return this.parseUrlGroup(optional);
+            throw new ParseError(
+                "Internal bug: 'url' arguments should be handled by Lexer",
+                this.nextToken);
         }
 
         // By the time we get here, type is one of "text" or "math".
@@ -699,51 +701,6 @@ export default class Parser {
             }
             lastToken = this.nextToken;
             str += lastToken.text;
-            this.consume();
-        }
-        this.mode = outerMode;
-        this.expect(optional ? "]" : "}");
-        return firstToken.range(lastToken, str);
-    }
-
-    /**
-     * Parses a group, essentially returning the string formed by the
-     * brace-enclosed tokens plus some position information, possibly
-     * with nested braces.
-     */
-    parseStringGroupWithBalancedBraces(
-        modeName: ArgType,  // Used to describe the mode in error messages.
-        optional: boolean,
-    ): ?Token {
-        if (optional && this.nextToken.text !== "[") {
-            return null;
-        }
-        const outerMode = this.mode;
-        this.mode = "text";
-        this.expect(optional ? "[" : "{");
-        let str = "";
-        let nest = 0;
-        const firstToken = this.nextToken;
-        let lastToken = firstToken;
-        while (nest > 0 || this.nextToken.text !== (optional ? "]" : "}")) {
-            if (this.nextToken.text === "EOF") {
-                throw new ParseError(
-                    "Unexpected end of input in " + modeName,
-                    firstToken.range(this.nextToken, str));
-            }
-            lastToken = this.nextToken;
-            str += lastToken.text;
-            if (lastToken.text === "{") {
-                nest += 1;
-            } else if (lastToken.text === "}") {
-                if (nest <= 0) {
-                    throw new ParseError(
-                        "Unbalanced brace of input in " + modeName,
-                        firstToken.range(this.nextToken, str));
-                } else {
-                    nest -= 1;
-                }
-            }
             this.consume();
         }
         this.mode = outerMode;
@@ -793,32 +750,6 @@ export default class Parser {
             throw new ParseError("Invalid color: '" + res.text + "'", res);
         }
         return newArgument(new ParseNode("color-token", match[0], this.mode), res);
-    }
-
-    /**
-     * Parses a url string.
-     */
-    parseUrlGroup(optional: boolean): ?ParsedArg {
-        const res = this.parseStringGroupWithBalancedBraces("url", optional);
-        if (!res) {
-            return null;
-        }
-        const raw = res.text;
-        // hyperref package allows backslashes alone in href, but doesn't generate
-        // valid links in such cases; we interpret this as "undefiend" behaviour,
-        // and keep them as-is. Some browser will replace backslashes with
-        // forward slashes.
-        const url = raw.replace(/\\([#$%&~_^{}])/g, '$1');
-        const protocol = /^\s*([^\\/#]*?)(?::|&#0*58|&#x0*3a)/i.exec(url);
-        const allowed = this.settings.allowedProtocols;
-        if (!utils.contains(allowed,  "*") && !utils.contains(allowed,
-                protocol != null ? protocol[1] : "_relative")) {
-            throw new ParseError('Not allowed \\href protocol', res);
-        }
-        return newArgument(new ParseNode("url", {
-            type: "url",
-            value: url,
-        }, this.mode), res);
     }
 
     /**
@@ -957,6 +888,45 @@ export default class Parser {
             // The token will be consumed later in parseGivenFunction
             // (after possibly switching modes).
             return newFunction(nucleus);
+        } else if (/^\\(href|url)[^a-zA-Z]/.test(text)) {
+            const match = text.match(urlFunctionRegex);
+            const funcName = match[1];
+            // match[2] is the only one that can be an empty string,
+            // so it must be at the end of the following or chain:
+            const rawUrl = match[4] || match[3] || match[2];
+            // hyperref package allows backslashes alone in href, but doesn't
+            // generate valid links in such cases; we interpret this as
+            // "undefined" behaviour, and keep them as-is. Some browser will
+            // replace backslashes with forward slashes.
+            const url = rawUrl.replace(/\\([#$%&~_^{}])/g, '$1');
+            const protocol = /^\s*([^\\/#]*?)(?::|&#0*58|&#x0*3a)/i.exec(url);
+            const allowed = this.settings.allowedProtocols;
+            if (!utils.contains(allowed,  "*") && !utils.contains(allowed,
+                    protocol != null ? protocol[1] : "_relative")) {
+                throw new ParseError('Not allowed \\href protocol', nucleus);
+            }
+            const urlArg = new ParseNode("url", {
+                type: "url",
+                value: url,
+            }, this.mode);
+            this.consume();
+            if (funcName === "\\href") {
+                this.consumeSpaces();  // ignore spaces between arguments
+                let description = this.parseGroupOfType("original", false);
+                if (description == null) {
+                    throw new ParseError("\\href missing second argument",
+                        nucleus);
+                }
+                if (description.type === "fn") {
+                    description = this.parseGivenFunction(description);
+                } else { // arg.type === "arg"
+                    description = description.result;
+                }
+                return newArgument(this.callFunction(
+                    funcName, [urlArg, description], []));
+            } else {  // \url
+                return newArgument(this.callFunction(funcName, [urlArg], []));
+            }
         } else if (/^\\verb[^a-zA-Z]/.test(text)) {
             this.consume();
             let arg = text.slice(5);

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -28,7 +28,7 @@ import type {EnvSpec} from "./defineEnvironment";
  *
  * The main functions (the `.parse...` ones) take a position in the current
  * parse string to parse tokens from. The lexer (found in Lexer.js, stored at
- * this.lexer) also supports pulling out tokens at arbitrary places. When
+ * this.gullet.lexer) also supports pulling out tokens at arbitrary places. When
  * individual tokens are needed at a position, the lexer is called to pull out a
  * token, which is then used.
  *

--- a/src/functions/href.js
+++ b/src/functions/href.js
@@ -14,6 +14,7 @@ defineFunction({
     props: {
         numArgs: 2,
         argTypes: ["url", "original"],
+        allowedInText: true,
     },
     handler: ({parser}, args) => {
         const body = args[1];
@@ -39,5 +40,36 @@ defineFunction({
         const math = mml.buildExpressionRow(group.value.body, options);
         assertType(math, MathNode).setAttribute("href", group.value.href);
         return math;
+    },
+});
+
+defineFunction({
+    type: "href",
+    names: ["\\url"],
+    props: {
+        numArgs: 1,
+        argTypes: ["url"],
+        allowedInText: true,
+    },
+    handler: ({parser}, args) => {
+        const href = assertNodeType(args[0], "url").value.value;
+        const chars = [];
+        for (let i = 0; i < href.length; i++) {
+            let c = href[i];
+            if (c === "~") {
+                c = "\\textasciitilde";
+            }
+            chars.push(new ParseNode("textord", c, "text"));
+        }
+        const body = new ParseNode("text", {
+            type: "text",
+            font: "\\texttt",
+            body: chars,
+        }, parser.mode);
+        return new ParseNode("href", {
+            type: "href",
+            href: href,
+            body: ordargument(body),
+        }, parser.mode);
     },
 });

--- a/test/__snapshots__/katex-spec.js.snap
+++ b/test/__snapshots__/katex-spec.js.snap
@@ -27,9 +27,7 @@ exports[`A begin/end parser should grab \\arraystretch 1`] = `
                         "end": 37,
                         "lexer": {
                           "input": "\\\\def\\\\arraystretch{1.5}\\\\begin{matrix}a&b\\\\\\\\c&d\\\\end{matrix}",
-                          "tokenRegex": {
-                            "lastIndex": 56
-                          }
+                          "lastIndex": 56
                         },
                         "start": 36
                       },
@@ -58,9 +56,7 @@ exports[`A begin/end parser should grab \\arraystretch 1`] = `
                         "end": 39,
                         "lexer": {
                           "input": "\\\\def\\\\arraystretch{1.5}\\\\begin{matrix}a&b\\\\\\\\c&d\\\\end{matrix}",
-                          "tokenRegex": {
-                            "lastIndex": 56
-                          }
+                          "lastIndex": 56
                         },
                         "start": 38
                       },
@@ -91,9 +87,7 @@ exports[`A begin/end parser should grab \\arraystretch 1`] = `
                         "end": 42,
                         "lexer": {
                           "input": "\\\\def\\\\arraystretch{1.5}\\\\begin{matrix}a&b\\\\\\\\c&d\\\\end{matrix}",
-                          "tokenRegex": {
-                            "lastIndex": 56
-                          }
+                          "lastIndex": 56
                         },
                         "start": 41
                       },
@@ -122,9 +116,7 @@ exports[`A begin/end parser should grab \\arraystretch 1`] = `
                         "end": 44,
                         "lexer": {
                           "input": "\\\\def\\\\arraystretch{1.5}\\\\begin{matrix}a&b\\\\\\\\c&d\\\\end{matrix}",
-                          "tokenRegex": {
-                            "lastIndex": 56
-                          }
+                          "lastIndex": 56
                         },
                         "start": 43
                       },

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -1563,8 +1563,9 @@ describe("A comment parser", function() {
         expect("% comment 1\n% comment 2\n").toParse();
     });
 
-    it("should not parse a comment that isn't followed by a newline", () => {
-        expect`x%y`.not.toParse();
+    it("should not parse a comment without newline in strict mode", () => {
+        expect`x%y`.not.toParse(strictSettings);
+        expect`x%y`.toParse(nonstrictSettings);
     });
 
     it("should not produce or consume space", () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,7 @@
 /* global expect: false */
 
 import stringify from 'json-stable-stringify';
+import Lexer from "../src/Lexer";
 import ParseError from "../src/ParseError";
 import {
     Mode, ConsoleWarning,
@@ -19,8 +20,16 @@ const typeFirstCompare = (a, b) => {
     }
 };
 
-const regExpReplacer = (key, value) => {
-    return value instanceof RegExp ? {lastIndex: value.lastIndex} : value;
+const replacer = (key, value) => {
+    if (value instanceof Lexer) {
+        return {
+            input: value.input,
+            // omit value.settings
+            lastIndex: value.tokenRegex.lastIndex,
+        };
+    } else {
+        return value;
+    }
 };
 
 const serializer = {
@@ -28,7 +37,7 @@ const serializer = {
         return stringify(val, {
             cmp: typeFirstCompare,
             space: '  ',
-            replacer: regExpReplacer,
+            replacer: replacer,
         });
     },
     test(val) {


### PR DESCRIPTION
1. **Comments without terminating newlines in nonstrict mode:** Fix #1506 by allowing single-line comments (`%` without terminating newline) in nonstrict mode.  `Lexer` and `MacroExpander` now store the `Settings` object, so the `Lexer` can complain about missing newline according to the `strict` setting.  I filtered this out from the snapshot tests with a slightly different `replacer`.

2. **Reimplement `\href` like `\verb`:** Major restructuring to lex URL arguments directly, e.g. to support `\href%{hello}` and `\href{http://foo.com/#test%}{hello}`.  The new URL parsing code is simpler, but involves a special case in `parseSymbol` like `\verb`.

3. **Add support for `\url`** while we're here.