### PR TITLE
Fix \textdaggerdbl

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -148,7 +148,7 @@ defineSymbol(text, main, textord, "\u2020", "\\dag");
 defineSymbol(text, main, textord, "\u2020", "\\textdagger");
 defineSymbol(math, main, textord, "\u2021", "\\ddag");
 defineSymbol(text, main, textord, "\u2021", "\\ddag");
-defineSymbol(text, main, textord, "\u2020", "\\textdaggerdbl");
+defineSymbol(text, main, textord, "\u2021", "\\textdaggerdbl");
 
 // Large Delimiters
 defineSymbol(math, main, close, "\u23b1", "\\rmoustache", true);


### PR DESCRIPTION
Fix #1538 by correcting the symbol mapping for `\textdaggerdbl`

![image](https://user-images.githubusercontent.com/2218736/43544433-db661088-95a0-11e8-832b-3905d0cede3e.png)
