### PR TITLE
Fix \neq line breaks

### DIFF
--- a/src/macros.js
+++ b/src/macros.js
@@ -368,7 +368,7 @@ defineMacro("\\not", '\\mathrel{\\mathrlap\\@not}');
 // \DeclareRobustCommand
 //   \notin{\mathrel{\m@th\mathpalette\c@ncel\in}}
 // \def\c@ncel#1#2{\m@th\ooalign{$\hfil#1\mkern1mu/\hfil$\crcr$#1#2$}}
-defineMacro("\\neq", "\\html@mathml{\\not=}{\\mathrel{\\char`≠}}");
+defineMacro("\\neq", "\\html@mathml{\\mathrel{\\not=}}{\\mathrel{\\char`≠}}");
 defineMacro("\\ne", "\\neq");
 defineMacro("\u2260", "\\neq");
 defineMacro("\\notin", "\\html@mathml{\\mathrel{{\\in}\\mathllap{/\\mskip1mu}}}"


### PR DESCRIPTION
Wrap the `\neq` macro inside a `\mathrel`, to prevent an inadvertent line break.  Fixes issue #1546.