### PR TITLE
ScrollSpy for table of contents

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -66,7 +66,10 @@ const siteConfig = {
 
     markdownPlugins: [require('./remarkableKatex'), require('./empty_thead')],
 
-    scripts: ['https://buttons.github.io/buttons.js'],
+    scripts: [
+        'https://buttons.github.io/buttons.js',
+        baseUrl + 'js/scrollspy.js',
+    ],
     stylesheets: ['https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css'],
 
     separateCss: ['static/static', 'static\\static'],

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,3 +1,17 @@
+ul.toc-headings > li {
+    padding-bottom: 0px;   /* moved to li > a */
+}
+
+.toc-headings > li > a {
+    display: block;
+    padding: 4px;
+}
+
+.toc-headings > li > a.active {
+    background-color: rgba(27, 31, 35, 0.05);
+    font-weight: bold;
+}
+
 .fixedHeaderContainer header img {
     height: 80%;
 }

--- a/website/static/js/scrollspy.js
+++ b/website/static/js/scrollspy.js
@@ -7,6 +7,8 @@ const onScroll = () => {
     timer = setTimeout(() => {
         let found = false;
         const headings = document.querySelectorAll('.toc-headings > li > a');
+        // Some computations based on
+        // https://github.com/makotot/scrollspy/blob/master/src/js/modules/scrollspy.js
         const scrollTop = document.documentElement.scrollTop ||
             document.body.scrollTop;
         const scrollBottom = scrollTop + window.innerHeight;

--- a/website/static/js/scrollspy.js
+++ b/website/static/js/scrollspy.js
@@ -1,0 +1,35 @@
+const epsilon = 10;
+let timer;
+const onScroll = () => {
+    if (timer) {  // throttle
+        return;
+    }
+    timer = setTimeout(() => {
+        let found = false;
+        const headings = document.querySelectorAll('.toc-headings > li > a');
+        const scrollTop = document.documentElement.scrollTop ||
+            document.body.scrollTop;
+        const scrollBottom = scrollTop + window.innerHeight;
+        for (let i = 0; i < headings.length; i++) {
+            // if !found and i is the last element, highlight the last
+            let current = !found;
+            if (!found && i < headings.length - 1) {
+                const next = headings[i + 1].href.split('#')[1];
+                const nextHeader = document.getElementById(next);
+                const top = nextHeader.getBoundingClientRect().top + scrollTop;
+                current = top > scrollTop + epsilon;
+            }
+            if (current) {
+                found = true;
+                headings[i].className = "active";
+            } else {
+                headings[i].className = "";
+            }
+        }
+        timer = null;
+    }, 50);
+};
+document.addEventListener('scroll', onScroll);
+document.addEventListener('resize', onScroll);
+document.addEventListener('ready', onScroll);
+onScroll();


### PR DESCRIPTION
Fix #1537 by adding automatic highlighting of currently visible topmost table of contents item.

This sometimes doesn't do an initial highlight, I guess because the table of contents isn't rendered at the beginning?  Is there a way to fix this?  But it works when scrolling and resizing.

Based on https://github.com/Khan/KaTeX/issues/1537#issuecomment-409616103 and https://github.com/makotot/scrollspy/blob/master/src/js/modules/scrollspy.js