### PR TITLE
Test that \neq is in a group

### DIFF
--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -92,6 +92,7 @@ describe("A rel parser", function() {
         for (let i = 0; i < parse.length; i++) {
             let group = parse[i];
             if (group.type === "htmlmathml") {
+                expect(group.html).toHaveLength(1);
                 group = group.html[0];
             }
             if (group.type === "mclass") {


### PR DESCRIPTION
Based on https://github.com/Khan/KaTeX/pull/1548#issuecomment-411273403.  It turned out to be a one-line change to confirm that the contents of the `\html@mathml` object was a single thing.  I confirmed that 

```js
defineMacro("\\neq", "\\html@mathml{\\not=}{\\mathrel{\\char`≠}}");
```

(i.e. without the `\mathrel` wrapper) fails.  However, the following would pass:

```js
defineMacro("\\neq", "\\not=");
```

To catch that case, we'd need to run each example separately and confirm that it expands to a single thing...