### PR TITLE
Improve examples, add defer, async, and pre- loading KaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,31 @@ Try out KaTeX [on the demo page](https://khan.github.io/KaTeX/#demo)!
 
 ## Getting started
 
-[Download KaTeX](https://github.com/khan/katex/releases) and host it on your server or include the `katex.min.js` and `katex.min.css` files on your page directly from a CDN:
+### Starter template
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" integrity="sha384-9tPv11A+glH/on/wEu99NVwDPwkMQESOocs/ZGXPoIiLE8MU/qkqUcZ3zzL+6DuH" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js" integrity="sha384-U8Vrjwb8fuHMt6ewaCy8uqeUXv4oitYACKdB0VziCerzt011iQ/0TqlSlv8MReCm" crossorigin="anonymous"></script>
+<!DOCTYPE html>
+<!-- KaTeX requires the use of the HTML5 doctype. Without it, KaTeX may not render properly -->
+<html>
+  <head>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" integrity="sha384-9tPv11A+glH/on/wEu99NVwDPwkMQESOocs/ZGXPoIiLE8MU/qkqUcZ3zzL+6DuH" crossorigin="anonymous">
+
+    <!-- The loading of KaTeX is deferred to speed up page rendering -->
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js" integrity="sha384-U8Vrjwb8fuHMt6ewaCy8uqeUXv4oitYACKdB0VziCerzt011iQ/0TqlSlv8MReCm" crossorigin="anonymous"></script>
+
+    <!-- To automatically render math in text elements, include the auto-render extension: -->
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/contrib/auto-render.min.js" integrity="sha384-aGfk5kvhIq5x1x5YdvCp4upKZYnA8ckafviDpmWEKp4afOZEqOli7gqSnh8I6enH" crossorigin="anonymous"
+        onload="renderMathInElement(document.body);"></script>
+  </head>
+  ...
+</html>
 ```
+
+You can also [download KaTeX](https://github.com/khan/katex/releases) and host it yourself.
+
+For details on how to configure auto-render extension, refer to [the documentation](https://khan.github.io/KaTeX/docs/autorender.html).
+
+### API
 
 #### In-browser rendering
 
@@ -44,27 +63,6 @@ try {
 ```
 
 If KaTeX can't parse the expression, it throws a `katex.ParseError` error.
-
-#### Rendering expressions in text elements
-
-To automatically render math in text elements, include the [auto-render script](https://khan.github.io/KaTeX/docs/autorender.html) `contrib/auto-render.min.js`, or via CDN:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/contrib/auto-render.min.js" integrity="sha384-aGfk5kvhIq5x1x5YdvCp4upKZYnA8ckafviDpmWEKp4afOZEqOli7gqSnh8I6enH" crossorigin="anonymous"></script>
-````
-
-Then, call the `renderMathInElement` function with a DOM element containing expressions in a script tag before the closing body tag:
-
-```html
-<body>
-  ...
-  <script>
-    renderMathInElement(document.body);
-  </script>
-</body>
-```
-
-See [Auto-render Extension](https://khan.github.io/KaTeX/docs/autorender.html) for more details.
 
 #### Server side rendering or rendering to a string
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,15 @@ Try out KaTeX [on the demo page](https://khan.github.io/KaTeX/#demo)!
 Call `katex.render` with a TeX expression and a DOM element to render into:
 
 ```js
-katex.render("c = \\pm\\sqrt{a^2 + b^2}", element);
+try {
+    katex.render("c = \\pm\\sqrt{a^2 + b^2}", element);
+} catch (e) {
+    if (e instanceof katex.ParseError) {
+        // KaTeX can't parse the expression
+    } else {
+        throw e;
+    }
+}
 ```
 
 If KaTeX can't parse the expression, it throws a `katex.ParseError` error.
@@ -63,8 +71,16 @@ See [Auto-render Extension](https://khan.github.io/KaTeX/docs/autorender.html) f
 To generate HTML on the server or to generate an HTML string of the rendered math, you can use `katex.renderToString`:
 
 ```js
-var html = katex.renderToString("c = \\pm\\sqrt{a^2 + b^2}");
-// '<span class="katex">...</span>'
+try {
+    var html = katex.renderToString("c = \\pm\\sqrt{a^2 + b^2}");
+    // '<span class="katex">...</span>'
+} catch (e) {
+    if (e instanceof katex.ParseError) {
+        // KaTeX can't parse the expression
+    } else {
+        throw e;
+    }
+}
 ```
 
 Make sure to include the CSS and font files, but there is no need to include the JavaScript. Like `render`, `renderToString` throws if it can't parse the expression.

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,15 @@ title: API
 Call `katex.render` with a TeX expression and a DOM element to render into:
 
 ```js
-katex.render("c = \\pm\\sqrt{a^2 + b^2}", element);
+try {
+    katex.render("c = \\pm\\sqrt{a^2 + b^2}", element);
+} catch (e) {
+    if (e instanceof katex.ParseError) {
+        // KaTeX can't parse the expression
+    } else {
+        throw e;
+    }
+}
 ```
 
 To avoid escaping the backslash (double backslash), you can use
@@ -23,6 +31,14 @@ See [handling errors](error.md) for configuring how to handle errors.
 To generate HTML on the server or to generate an HTML string of the rendered math, you can use `katex.renderToString`:
 
 ```js
-var html = katex.renderToString("c = \\pm\\sqrt{a^2 + b^2}");
-// '<span class="katex">...</span>'
+try {
+    var html = katex.renderToString("c = \\pm\\sqrt{a^2 + b^2}");
+    // '<span class="katex">...</span>'
+} catch (e) {
+    if (e instanceof katex.ParseError) {
+        // KaTeX can't parse the expression
+    } else {
+        throw e;
+    }
+}
 ```

--- a/docs/autorender.md
+++ b/docs/autorender.md
@@ -13,37 +13,20 @@ using a CDN:
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" integrity="sha384-9tPv11A+glH/on/wEu99NVwDPwkMQESOocs/ZGXPoIiLE8MU/qkqUcZ3zzL+6DuH" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js" integrity="sha384-U8Vrjwb8fuHMt6ewaCy8uqeUXv4oitYACKdB0VziCerzt011iQ/0TqlSlv8MReCm" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/contrib/auto-render.min.js" integrity="sha384-aGfk5kvhIq5x1x5YdvCp4upKZYnA8ckafviDpmWEKp4afOZEqOli7gqSnh8I6enH" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js" integrity="sha384-U8Vrjwb8fuHMt6ewaCy8uqeUXv4oitYACKdB0VziCerzt011iQ/0TqlSlv8MReCm" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/contrib/auto-render.min.js" integrity="sha384-aGfk5kvhIq5x1x5YdvCp4upKZYnA8ckafviDpmWEKp4afOZEqOli7gqSnh8I6enH" crossorigin="anonymous"
+    onload="renderMathInElement(document.body);"></script>
 ```
 
-Then, call the exposed `renderMathInElement` function in a script tag
-before the close body tag:
+> The loading of scripts are [deferred using `defer` attribute](https://developer.mozilla.org/en/HTML/Element/script#Attributes)
+to speed up page rendering and `renderMathInElement` is called after auto-render
+script is loaded using `onload` attribute. You can also call the
+`renderMathInElement` when (or after) [`DOMContentLoaded` event is fired on the
+`document`](https://developer.mozilla.org/ko/docs/Web/Reference/Events/DOMContentLoaded).
 
-```html
-<body>
-  ...
-  <script>
-    renderMathInElement(document.body);
-  </script>
-</body>
-```
-
-If you prefer to have all your setup inside the html `<head>`,
-you can use the following script there
-(instead of the one above at the end of the `<body>`):
-
-```html
-<head>
-  ...
-  <script>
-    document.addEventListener("DOMContentLoaded", function() {
-      renderMathInElement(document.body);
-    });
-  </script>
-  ...
-</head>
-```
+> If you do not use `defer` attribute, `renderMathInElement` should be called
+right before the closing body tag(`</body>`) or when (or after) `DOMContentLoaded`
+event is fired on the `document`.
 
 ## API
 This extension exposes a single function, `window.renderMathInElement`, with

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -25,6 +25,17 @@ to speed up page rendering. The `katex` object will be available after
 If you do not use `defer`, `katex` object will be available after corresponding
 `script` tag.
 
+> If KaTeX is not used immediately or not critical, you can load KaTeX
+asynchronously. Add [`async` attribute](https://developer.mozilla.org/en/HTML/Element/script#Attributes)
+to `script` and use [`rel="preload"` and `onload` attribute](https://github.com/filamentgroup/loadCSS)
+on `link`.
+
+> You can prefetch KaTeX fonts to prevent FOUT or FOIT. Use [Web Font Loader](https://github.com/typekit/webfontloader)
+or add [`<link rel="preload" href=(path to WOFF2 font) as="font" type="font/woff2" crossorigin="anonymous">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content)
+to `head`. (Note that only few browsers [support `rel="preload"`](https://caniuse.com/#feat=link-rel-preload),
+and they all support WOFF2 so preloading WOFF2 fonts is enough.) You can use
+Chrome DevTools Network panel or similar to view which fonts are used.
+
 ## Download & Host Things Yourself
 Download a [KaTeX release](https://github.com/Khan/KaTeX/releases),
 copy `katex.js`, `katex.css`

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -8,16 +8,22 @@ title: Browser
 Use CDN to deliver KaTeX to your project:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.js" integrity="sha256-9uW7yW4EwdUyWU2PHu+Ccek7+xbQpDTDS5OBP0qDrTM=" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.css" integrity="sha256-T4bfkilI7rlQXG1R8kqn+FGhe56FhZmqmp9x75Lw4s8=" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.js" integrity="sha256-9uW7yW4EwdUyWU2PHu+Ccek7+xbQpDTDS5OBP0qDrTM=" crossorigin="anonymous"></script>
 ```
 
 KaTeX also provides minified versions:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js" integrity="sha256-mxaM9VWtRj1wBtn50/EDUUe4m3t39ExE+xEPyrxVB8I=" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" integrity="sha256-sI/DdD47R/Sa54XZDNFjRWlS+Dv8MC5xfkqQLRh0Jes=" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.js" integrity="sha256-mxaM9VWtRj1wBtn50/EDUUe4m3t39ExE+xEPyrxVB8I=" crossorigin="anonymous"></script>
 ```
+
+> The loading of scripts are [deferred using `defer` attribute](https://developer.mozilla.org/en/HTML/Element/script#Attributes).
+to speed up page rendering. The `katex` object will be available after
+[`DOMContentLoaded` event is fired on the `document`](https://developer.mozilla.org/ko/docs/Web/Reference/Events/DOMContentLoaded).
+If you do not use `defer`, `katex` object will be available after corresponding
+`script` tag.
 
 ## Download & Host Things Yourself
 Download a [KaTeX release](https://github.com/Khan/KaTeX/releases),


### PR DESCRIPTION
* Wrap `katex.render` examples with try...catch: fixes #275 
* Add starter template
  * Add HTML5 doctype: fixes #661 
  * Defer loading javascripts: fixes #1578
* Update documentation to use `defer` and `onload`: see #1578
* Add documentation on async and pre- loading KaTeX: fixes #1064 