### PR TITLE
[2-1] Do not publish master documentation to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ diff.png
 /test/screenshotter/unicode-fonts
 coverage/
 docs/cli.md
+docs.bak
 lib/core/metadata.js
 lib/core/MetadataBlog.js
 website/translated_docs

--- a/website/lib/build.js
+++ b/website/lib/build.js
@@ -1,11 +1,5 @@
 const fs = require('fs-extra');
 
-if (process.env.npm_lifecycle_event === 'postpublish-gh-pages') {
-    fs.removeSync('../docs');
-    fs.moveSync('../docs.bak', '../docs');
-    process.exit();
-}
-
 // generate cli.md
 const cli = require('../../cli');
 const template = fs.readFileSync('../docs/cli.md.template');

--- a/website/lib/build.js
+++ b/website/lib/build.js
@@ -1,5 +1,11 @@
 const fs = require('fs-extra');
 
+if (process.env.npm_lifecycle_event === 'postpublish-gh-pages') {
+    fs.removeSync('../docs');
+    fs.moveSync('../docs.bak', '../docs');
+    process.exit();
+}
+
 // generate cli.md
 const cli = require('../../cli');
 const template = fs.readFileSync('../docs/cli.md.template');
@@ -11,6 +17,16 @@ ${option.description}${((option.bool && option.defaultValue !== undefined)
 `),
     '### `-h, --help`\nOutput usage information', ''].join('\n'));
 
-// copy local built CSS and fonts
-fs.copySync('../dist/katex.min.css', 'static/static/katex.min.css');
-fs.copySync('../dist/fonts', 'static/static/fonts');
+if (process.env.npm_lifecycle_event !== 'publish-gh-pages') {
+    // copy local built CSS and fonts
+    fs.copySync('../dist/katex.min.css', 'static/static/katex.min.css');
+    fs.copySync('../dist/fonts', 'static/static/fonts');
+} else {
+    // do not publish master (next) documentation on gh-pages
+    fs.removeSync('static/static/katex.min.css');
+    fs.removeSync('static/static/fonts');
+
+    fs.removeSync('../docs.bak');
+    fs.moveSync('../docs', '../docs.bak');
+    fs.ensureDirSync('../docs');
+}

--- a/website/lib/postbuild.js
+++ b/website/lib/postbuild.js
@@ -1,0 +1,6 @@
+const fs = require('fs-extra');
+
+if (process.env.npm_lifecycle_event === 'publish-gh-pages') {
+    fs.removeSync('../docs');
+    fs.moveSync('../docs.bak', '../docs');
+}

--- a/website/package.json
+++ b/website/package.json
@@ -2,8 +2,7 @@
   "scripts": {
     "start": "node lib/build.js && docusaurus-start",
     "build": "node lib/build.js && docusaurus-build",
-    "publish-gh-pages": "node lib/build.js && docusaurus-publish",
-    "postpublish-gh-pages": "node lib/build.js",
+    "publish-gh-pages": "node lib/build.js && docusaurus-publish && node lib/postbuild.js",
     "write-translations": "docusaurus-write-translations",
     "version": "node lib/build.js && docusaurus-version",
     "rename-version": "docusaurus-rename-version"

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,7 @@
     "start": "node lib/build.js && docusaurus-start",
     "build": "node lib/build.js && docusaurus-build",
     "publish-gh-pages": "node lib/build.js && docusaurus-publish",
+    "postpublish-gh-pages": "node lib/build.js",
     "write-translations": "docusaurus-write-translations",
     "version": "node lib/build.js && docusaurus-version",
     "rename-version": "docusaurus-rename-version"

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -47,26 +47,29 @@ function Versions(props) {
                 </tr>
               </tbody>
             </table>
-            <h3 id="rc">Latest Version</h3>
-            <p>
-              Here you can find the latest documentation and unreleased code.
-            </p>
-            <table className="versions">
-              <tbody>
-                <tr>
-                  <th>master</th>
-                  <td>
-                    <a
-                      href={`${baseUrl}docs/${language}next/node.html`}>
-                      Documentation
-                    </a>
-                  </td>
-                  <td>
-                    <a href={repoUrl}>Source Code</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            {process.env.npm_lifecycle_event !== 'publish-gh-pages' &&
+              <div>
+                <h3 id="rc">Latest Version</h3>
+                <p>
+                  Here you can find the latest documentation and unreleased code.
+                </p>
+                <table className="versions">
+                  <tbody>
+                    <tr>
+                      <th>master</th>
+                      <td>
+                        <a href={`${baseUrl}docs/${language}next/node.html`}>
+                          Documentation
+                        </a>
+                      </td>
+                      <td>
+                        <a href={repoUrl}>Source Code</a>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            }
             <h3 id="archive">Past Versions</h3>
             <p>
               Here you can find documentation for previous versions of KaTeX.


### PR DESCRIPTION
Part of https://github.com/Khan/KaTeX/issues/1509#issuecomment-412148173.

* Do not publish `master` (next) documentation to GitHub Pages
  * Does not publish local built CSS and fonts