### PR TITLE
[2-2] Use build artifacts on GitHub Pages master documentation

### DIFF
--- a/website/lib/build.js
+++ b/website/lib/build.js
@@ -11,6 +11,12 @@ ${option.description}${((option.bool && option.defaultValue !== undefined)
 `),
     '### `-h, --help`\nOutput usage information', ''].join('\n'));
 
-// copy local built CSS and fonts
-fs.copySync('../dist/katex.min.css', 'static/static/katex.min.css');
-fs.copySync('../dist/fonts', 'static/static/fonts');
+if (!process.env.CIRCLE_BUILD_NUM) {
+    // copy local built CSS and fonts
+    fs.copySync('../dist/katex.min.css', 'static/static/katex.min.css');
+    fs.copySync('../dist/fonts', 'static/static/fonts');
+} else {
+    // do not publish local built CSS and fonts to gh-pages
+    fs.removeSync('static/static/katex.min.css');
+    fs.removeSync('static/static/fonts');
+}

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -8,6 +8,9 @@
 // See https://docusaurus.io/docs/site-config.html for all the possible
 // site configuration options.
 
+const ARTIFACTS_URL = 'https://katex.ylem.kim/';
+const BUILD_NUM = process.env.CIRCLE_BUILD_NUM;
+
 // If BASE_URL environment variable is set, use it as baseUrl.
 // If on netlify, use '/'. Otherwise use '/KaTeX/'.
 const baseUrl = process.env.BASE_URL || (process.env.CONTEXT ? '/' : '/KaTeX/');
@@ -17,8 +20,9 @@ const {Plugin: Embed} = require('remarkable-embed');
 const embed = new Embed();
 
  // {@stylesheet: path}
-embed.register('stylesheet',
-    path => `<link rel="stylesheet" href="${baseUrl}static/${path}"/>`);
+embed.register('stylesheet', path => `<link rel="stylesheet" href="${
+        BUILD_NUM ? `${ARTIFACTS_URL}${BUILD_NUM}` : `${baseUrl}static`
+    }/${path}" crossorigin="anonymous"/>`);
 
 /* List of projects/orgs using your project for the users page */
 const users = [


### PR DESCRIPTION
Part of https://github.com/Khan/KaTeX/issues/1509#issuecomment-412148173.

This requires build artifacts server, which can be done by one of following ways:

## Use files deployed to netlify
* Pros: No need to set up another service

1. **[PR revision required]** Change to use build number as query string, i.e., `${ARTIFACTS_URL}${BUILD_NUM}/${path}` to `${ARTIFACTS_URL}${path}?${BUILD_NUM}`. Set `Access-Control-Allow-Origin` header.

## Use CircleCI build artifacts, with CORS reverse proxy
* Pros: No additional cost, artifacts and the website is built in the same CircleCI build
* Cons: May become unavailable in the future
  * > Artifacts are designed to be useful around the time of the build. It is best practice not to rely on artifacts as a software distribution mechanism with long term future guarantees.

1. Deploy proxy (https://github.com/ylemkimon/katex-build-artifacts) to [now.sh](https://zeit.co/now)

## Setup artifacts storage, e.g., [AWS S3](https://aws.amazon.com/s3/)
* Pros: Fast and able to control lifetime of artifacts
* Cons: Requires additional cost. However, AWS S3 provides 1 year free tier and is inexpensive

1. Setup a artifact storage, e.g., [AWS S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html)
2. **[PR revision required]** [Setup CircleCI to upload (deploy) artifacts to the storage](https://circleci.com/docs/2.0/deployment-integrations/)

## Common steps

1. Assign a domain name
2. Setup [Cloudflare](https://www.cloudflare.com/) on the domain to cache/deliver
> Cloudflare for netlify may not be needed, as it provides 100 GB/month bandwidth
3. **[PR revision required]** Set `ARTIFACTS_URL` to the domain