### PR TITLE
[2-1+]  Do not deploy versioned docs on netlify production deploy

### DIFF
--- a/website/lib/build.js
+++ b/website/lib/build.js
@@ -14,3 +14,8 @@ ${option.description}${((option.bool && option.defaultValue !== undefined)
 // copy local built CSS and fonts
 fs.copySync('../dist/katex.min.css', 'static/static/katex.min.css');
 fs.copySync('../dist/fonts', 'static/static/fonts');
+
+if (process.env.CONTEXT === 'production') {
+    // do not deploy versioned docs to netlify production deploy
+    fs.removeSync('versions.json');
+}


### PR DESCRIPTION
Part of https://github.com/Khan/KaTeX/issues/1509#issuecomment-412148173. Addition to #1585.

* Do not deploy versioned docs, i.e., deploy only master docs, on netlify production deploy (http://katex.netlify.com)