### PR TITLE
Fix CircleCI Chrome build hanging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,11 +92,13 @@ jobs:
     docker:
       - image: circleci/node:6
       - image: selenium/standalone-chrome:2.48.2
+        environment:
+          DBUS_SESSION_BUS_ADDRESS: /dev/null
     <<: *screenshotter
 
 workflows:
   version: 2
-  screenshotter:
+  test:
     jobs:
       - test
       - firefox


### PR DESCRIPTION
There were several instances of Chrome build failing due to timeout. It turns out that it is a known issue with a fix: https://github.com/SeleniumHQ/docker-selenium/issues/87. Hopefully this will fix it.

\+ Change workflow name to `test`