### PR TITLE
Remove Object.assign() in auto-render which requires expensive polyfill, update LICENSE

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -71,7 +71,7 @@
         "require-jsdoc": 0
     },
     "overrides": [{
-        "files": ["katex.js", "src/**/*.js"],
+        "files": ["katex.js", "src/**/*.js", "contrib/**/*.js"],
         "excludedFiles": "unicodeMake.js",
         "rules": {
             "no-restricted-syntax": [2, "ForOfStatement", "ClassDeclaration[superClass]", "ClassExpression[superClass]"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Khan Academy
+Copyright (c) 2013-2018 Khan Academy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,12 +2,6 @@ The MIT License (MIT)
 
 Copyright (c) 2015 Khan Academy
 
-This software also uses portions of the underscore.js project, which is
-MIT licensed with the following copyright:
-
-Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
-Reporters & Editors
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/contrib/auto-render/auto-render.js
+++ b/contrib/auto-render/auto-render.js
@@ -75,8 +75,22 @@ const renderElem = function(elem, optionsCopy) {
     }
 };
 
-const defaultAutoRenderOptions = {
-    delimiters: [
+const renderMathInElement = function(elem, options) {
+    if (!elem) {
+        throw new Error("No element provided to render");
+    }
+
+    const optionsCopy = {};
+
+    // Object.assign(optionsCopy, option)
+    for (const option in options) {
+        if (options.hasOwnProperty(option)) {
+            optionsCopy[option] = option;
+        }
+    }
+
+    // default options
+    optionsCopy.delimiters = optionsCopy.delimiters || [
         {left: "$$", right: "$$", display: true},
         {left: "\\(", right: "\\)", display: false},
         // LaTeX uses $…$, but it ruins the display of normal `$` in text:
@@ -87,31 +101,16 @@ const defaultAutoRenderOptions = {
         // That makes it susceptible to finding a \\[0.3em] row delimiter and
         // treating it as if it were the start of a KaTeX math zone.
         {left: "\\[", right: "\\]", display: true},
-    ],
-
-    ignoredTags: [
+    ];
+    optionsCopy.ignoredTags = optionsCopy.ignoredTags || [
         "script", "noscript", "style", "textarea", "pre", "code",
-    ],
-
-    ignoredClasses: [],
-
-    errorCallback: function(msg, err) {
-        console.error(msg, err);
-    },
-};
-
-const renderMathInElement = function(elem, options) {
-    if (!elem) {
-        throw new Error("No element provided to render");
-    }
-
-    const optionsCopy = Object.assign({}, defaultAutoRenderOptions, options);
+    ];
+    optionsCopy.ignoredClasses = optionsCopy.ignoredClasses || [];
+    optionsCopy.errorCallback = optionsCopy.errorCallback || console.error;
 
     // Enable sharing of global macros defined via `\gdef` between different
     // math elements within a single call to `renderMathInElement`.
-    if (!optionsCopy.macros) {
-        optionsCopy.macros = {};
-    }
+    optionsCopy.macros = optionsCopy.macros || {};
 
     renderElem(elem, optionsCopy);
 };


### PR DESCRIPTION
* Remove Object.assign() in auto-render which requires expensive polyfill
  * This reduces auto-render size from 26 KB (9 KB minified) to 12 KB (5 KB minified).
* Update LICENSE
  * `_.extend` of `underscore.js` was used in https://github.com/Khan/KaTeX/commit/cd9bca4a89eddd77c542e23a4a9dc2deff2ab72c#diff-61e0bdf7e1b43c5c93d9488b22e04170, but later removed in #656, but LICENSE was not updated
  * Renamed LICENSE.txt to LICENSE, which seems to be more common
  * Updated copyright year, the initial commit (https://github.com/Khan/KaTeX/commit/708a36502bea3b289fa4eac46c93478a5af3eca3) was 2013