### PR TITLE
Use CircleCI to publish release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,20 @@ jobs:
           path: dist/fonts
           destination: fonts
 
+      - run:
+          name: Deploy release version
+          command: |
+              NEW_VERSION=$(git diff -U0 HEAD^ -- website/versions.json |\
+                { grep '^+\s\+' || test $? = 1; } | sed -r 's/\+\s+"(.*)",?/\1/')
+              if [[ $CIRCLE_BRANCH == "master" && $NEW_VERSION ]]; then
+                git config --global user.email "katex@users.noreply.github.com"
+                git config --global user.name "KaTeX Release Bot"
+                echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+
+                ./release.sh -p $NEW_VERSION
+                node .circleci/create-github-release.js $NEW_VERSION
+              fi
+
   firefox:
     docker:
       - image: circleci/node:6

--- a/.circleci/create-github-release.js
+++ b/.circleci/create-github-release.js
@@ -1,0 +1,32 @@
+const octokit = require('@octokit/rest')();
+const fs = require('fs-extra');
+const path = require('path');
+
+const version = `v${process.argv[2]}`;
+const assets = ['katex.tar.gz', 'katex.zip'];
+
+octokit.authenticate({type: 'token', token: process.env.GH_TOKEN});
+
+octokit.repos.createRelease({
+    owner: process.env.CIRCLE_PROJECT_USERNAME,
+    repo: process.env.CIRCLE_PROJECT_REPONAME,
+    tag_name: version,
+    name: version,
+    target_commitish: 'master',
+}).then(result => {
+    const {data: {upload_url: uploadUrl}} = result;
+
+    return Promise.all(assets.map(asset => {
+        const file = fs.readFileSync(asset);
+        return octokit.repos.uploadAsset({
+            url: uploadUrl,
+            contentType: asset.endsWith('.zip') ? 'application/zip' : 'application/gzip',
+            contentLength: file.length,
+            name: asset,
+            file,
+        });
+    }));
+}).catch(e => {
+    console.error(e);
+    process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@octokit/rest": "^15.9.5",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.1.2",
     "babel-jest": "^23.0.1",
@@ -87,7 +88,7 @@
     "analyze": "webpack --config webpack.analyze.js",
     "build": "yarn prestart && rimraf dist/ && mkdirp dist && cp README.md dist && rollup -c && webpack",
     "watch": "yarn build --watch",
-    "dist": "yarn test && yarn build && yarn dist:zip",
+    "dist": "yarn build && yarn dist:zip",
     "dist:zip": "cd dist && tar czf ../katex.tar.gz * && zip -rq ../katex.zip *"
   },
   "dependencies": {

--- a/release.sh
+++ b/release.sh
@@ -211,6 +211,7 @@ else
 
     # Publish the website
     pushd website
+    yarn
     USE_SSH=true yarn publish-gh-pages
     popd
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,13 +103,26 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
+"@octokit/rest@^15.9.5":
+  version "15.9.5"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-15.9.5.tgz#e356d202bd0b517e381f705ad77d98ccb84e0c65"
+  dependencies:
+    before-after-hook "^1.1.0"
+    btoa-lite "^1.0.0"
+    debug "^3.1.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.0"
+    lodash "^4.17.4"
+    node-fetch "^2.1.1"
+    url-template "^2.0.8"
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
 
 "@types/node@*":
-  version "10.5.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.5.tgz#8e84d24e896cd77b0d4f73df274027e3149ec2ba"
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
 
 "@webassemblyjs/ast@1.5.13":
   version "1.5.13"
@@ -298,6 +311,12 @@ acorn-jsx@^4.1.1:
 acorn@^5.0.0, acorn@^5.0.3, acorn@^5.3.0, acorn@^5.5.3, acorn@^5.6.0, acorn@^5.6.2:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+
+agent-base@4, agent-base@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  dependencies:
+    es6-promisify "^5.0.0"
 
 ajv-errors@^1.0.0:
   version "1.0.0"
@@ -1073,6 +1092,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+before-after-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.1.0.tgz#83165e15a59460d13702cb8febd6a1807896db5a"
+
 benchmark@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
@@ -1244,6 +1267,10 @@ bser@^2.0.0:
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
+
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
 
 buffer-crc32@^0.2.5:
   version "0.2.13"
@@ -1992,7 +2019,7 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0:
+debug@3.1.0, debug@^3.0.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2345,9 +2372,19 @@ es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
+es6-promise@^4.0.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
 es6-promise@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
@@ -3296,6 +3333,13 @@ http-parser-js@>=0.4.0:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.13.tgz#3bd6d6fde6e3172c9334c3b33b6c193d80fe1137"
 
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
+
 http-proxy-middleware@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz#0987e6bb5a5606e5a69168d8f967a87f15dd8aab"
@@ -3324,6 +3368,13 @@ http-signature@~1.2.0:
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+
+https-proxy-agent@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
 
 husky@^1.0.0-rc.8:
   version "1.0.0-rc.13"
@@ -4924,6 +4975,10 @@ next-tick@1:
 nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
+node-fetch@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -7468,6 +7523,10 @@ url-parse@^1.1.8, url-parse@~1.4.0:
   dependencies:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
ac543c7

This requires:

## GitHub user token
1. Create a account
2. Grant it a push access to Khan/KaTeX
3. [Create a GitHub access token](https://github.com/settings/tokens) with `public_repo` permission
4. Add it to [CircleCI environment variable settings](https://circleci.com/gh/Khan/KaTeX/edit#env-vars) ([CircleCI docs](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)) as `GH_TOKEN`

and

## NPM token
1. Create a [NPM token](https://docs.npmjs.com/cli/token)
2. Add it to [CircleCI environment variable settings](https://circleci.com/gh/Khan/KaTeX/edit#env-vars) ([CircleCI docs](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)) as `NPM_TOKEN`