### PR TITLE
 Revert pkg.main to CommonJS (ES5) module and remove pkg.module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "katex",
   "version": "0.10.0-pre",
   "description": "Fast math typesetting for the web.",
-  "main": "dist/katex",
-  "module": "dist/katex.mjs",
+  "main": "dist/katex.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/Khan/KaTeX.git"


### PR DESCRIPTION
(Quick) workaround for #1652.

It seems a quite few people are affected by this, so I'm planning to release 0.10.0-rc.1 after this gets merged.