### PR TITLE
Add browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,11 @@
+# Last 2 versions of each browsers, excluding dead browsers (e.g., BlackBerry)
+last 2 versions
+not dead
+
+# Browsers with more than 0.1% global usage, excluding old browsers
+> 0.1%
+not chrome < 45
+not ie < 9
+
+# Currently maintained Node.js versions
+maintained node versions


### PR DESCRIPTION
Fixes #1466. This will not affect current codebase, but tools like `babel-preset-env` (Babel 7) will use it. (https://github.com/browserslist/browserslist)

This currently resolves to (only minimum version shown):
```
and_chr 67
and_ff 60
and_qq 1.2
and_uc 11.8
android 4.2
baidu 7.12
chrome 49
edge 16
firefox 52
ie 9
ie_mob 11
ios_saf 9.3
node 6.14.0
op_mini all
op_mob 46
opera 52
safari 9.1
samsung 4
```