### PR TITLE
package.json: script dist:zip packs with "katex" directory prefix again

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "build": "yarn prestart && rimraf dist/ && mkdirp dist && cp README.md dist && rollup -c && webpack",
     "watch": "yarn build --watch",
     "dist": "yarn test && yarn build && yarn dist:zip",
-    "dist:zip": "cd dist && tar czf ../katex.tar.gz * && zip -rq ../katex.zip *"
+    "dist:zip": "rimraf katex/ katex.tar.gz katex.zip && cp -R dist katex && tar czf katex.tar.gz katex && zip -rq katex.zip katex && rimraf katex/"
   },
   "dependencies": {
     "commander": "^2.16.0"


### PR DESCRIPTION
This addresses #1664. `yarn dist:zip` now creates a temporary copy of `dist` to `katex` and tars/zips that folder instead of just its contents. This restores the release structure before `v0.10.0-rc`.

Caveat: I am not familiar with `npm` nor `yarn` (beyond the basics) nor the KaTeX build system. I am familiar with Unix shell scripting however. Please review this pull request thoroughly. There may be other approaches that fit your philosophy or design goals better.

Details: `set -e` makes the shell exit on errors (in simple commands); this saves lots of `&&` and turns the `test ! -d katex` into an assertion. The `(...)` open a subshell. This might not be necessary if `yarn` uses a separate shell process for each script anyway, but I use parentheses as part of an idiom whenever I use `trap`. (Because it enables nesting, and with the parentheses you can try the script directly in an interactive `bash` session.) That `trap` registers cleanup commands, to be run whenever (and however) the subshell exits, i.e. at the `)` or upon errors (because of the `set -e`) or signals as sent by hitting Ctrl-C. In this case, the trap makes sure that the temporary `katex` folder is deleted on exit, even in case of errors.

The patch makes `yarn dist` produce `katex.tar.gz` and `katex.zip`, each containing a single (filled) folder `katex`. All five test suites invoked by `yarn test` pass.

I had to use `yarn upgrade` and my `yarn.lock` differs, but I have not included those changes because I think those are platform-specific.