### PR TITLE
Allow 6-digit color spec w/o #

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -508,7 +508,7 @@ $\textcolor{#228B22}{F=ma}$ `\textcolor{#228B22}{F=ma}`<br>
 $\colorbox{aqua}{A}$ `\colorbox{aqua}{A}`<br>
 $\fcolorbox{red}{aqua}{A}$ `\fcolorbox{red}{aqua}{A}`
 
-For color definition, KaTeX color functions will accept the standard HTML [predefined color names](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Color_keywords). They will also accept an RGB argument in CSS hexa­decimal style.
+For color definition, KaTeX color functions will accept the standard HTML [predefined color names](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Color_keywords). They will also accept an RGB argument in CSS hexa­decimal style. The "#" is optional before a six-digit specification.
 
 **Font**
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -749,7 +749,7 @@ export default class Parser {
         }
         let color = match[0];
         if (/^[0-9a-f]{6}$/i.test(color)) {
-            // We allow a 6-digit HTML color spec without a leading "#". 
+            // We allow a 6-digit HTML color spec without a leading "#".
             // This follows the xcolor package's HTML color model.
             // Predefined color names are all missed by this RegEx pattern.
             color = "#" + color;

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -743,14 +743,25 @@ export default class Parser {
         if (!res) {
             return null;
         }
-        const match = (/^(#[a-f0-9]{3}|#[a-f0-9]{6}|[a-z]+)$/i).exec(res.text);
+        const match = (/^(#[a-f0-9]{3}|#?[a-f0-9]{6}|[a-z]+)$/i).exec(res.text);
         if (!match) {
             throw new ParseError("Invalid color: '" + res.text + "'", res);
+        }
+        let color = match[0];
+        if (color.charAt(0) !== "#" && color.length === 6) {
+           // Check for HTML predefined color words that are 6 letters long.
+           // If not predefined, allow a 6-digit color specification without
+           // a leading #, as in the xcolor package's HTML color model.
+           const colorWordRegEx = RegExp("^(silver|maroon|purple|yellow|orange" +
+               "|bisque|indigo|orchid|salmon|sienna|tomato|violet)$",'i');
+           if (!colorWordRegEx.test(color)) {
+               color = "#" + color;
+           }
         }
         return newArgument({
             type: "color-token",
             mode: this.mode,
-            color: match[0],
+            color: color,
         }, res);
     }
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -757,7 +757,7 @@ export default class Parser {
         return newArgument({
             type: "color-token",
             mode: this.mode,
-            color: color,
+            color,
         }, res);
     }
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -748,15 +748,11 @@ export default class Parser {
             throw new ParseError("Invalid color: '" + res.text + "'", res);
         }
         let color = match[0];
-        if (color.charAt(0) !== "#" && color.length === 6) {
-           // Check for HTML predefined color words that are 6 letters long.
-           // If not predefined, allow a 6-digit color specification without
-           // a leading #, as in the xcolor package's HTML color model.
-           const colorWordRegEx = RegExp("^(silver|maroon|purple|yellow|orange" +
-               "|bisque|indigo|orchid|salmon|sienna|tomato|violet)$",'i');
-           if (!colorWordRegEx.test(color)) {
-               color = "#" + color;
-           }
+        if (/^[0-9a-f]{6}$/i.test(color)) {
+            // We allow a 6-digit HTML color spec without a leading "#". 
+            // This follows the xcolor package's HTML color model.
+            // Predefined color names are all missed by this RegEx pattern.
+            color = "#" + color;
         }
         return newArgument({
             type: "color-token",

--- a/test/errors-spec.js
+++ b/test/errors-spec.js
@@ -296,10 +296,10 @@ describe("Lexer:", function() {
     });
 
     describe("#_innerLexColor", function() {
-        it("reject hex notation without #", function() {
-            expect`\textcolor{1a2b3c}{foo}`.toFailWithParseError(
-                   "Invalid color: '1a2b3c'" +
-                   " at position 12: \\textcolor{1̲a̲2̲b̲3̲c̲}{foo}");
+        it("reject 3-digit hex notation without #", function() {
+            expect`\textcolor{1a2}{foo}`.toFailWithParseError(
+                   "Invalid color: '1a2'" +
+                   " at position 12: \\textcolor{1̲a̲2̲}{foo}");
         });
     });
 

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -780,6 +780,7 @@ describe("A color parser", function() {
     const newColorExpression = r`\redA{x}`;
     const customColorExpression1 = r`\textcolor{#fA6}{x}`;
     const customColorExpression2 = r`\textcolor{#fA6fA6}{x}`;
+    const customColorExpression3 = r`\textcolor{fA6fA6}{x}`;
     const badCustomColorExpression1 = r`\textcolor{bad-color}{x}`;
     const badCustomColorExpression2 = r`\textcolor{#fA6f}{x}`;
     const badCustomColorExpression3 = r`\textcolor{#gA6}{x}`;
@@ -800,14 +801,17 @@ describe("A color parser", function() {
     it("should parse a custom color", function() {
         expect(customColorExpression1).toParse();
         expect(customColorExpression2).toParse();
+        expect(customColorExpression3).toParse();
     });
 
     it("should correctly extract the custom color", function() {
         const parse1 = getParsed(customColorExpression1)[0];
         const parse2 = getParsed(customColorExpression2)[0];
+        const parse3 = getParsed(customColorExpression3)[0];
 
         expect(parse1.color).toEqual("#fA6");
         expect(parse2.color).toEqual("#fA6fA6");
+        expect(parse3.color).toEqual("#fA6fA6");
     });
 
     it("should not parse a bad custom color", function() {


### PR DESCRIPTION
This PR takes a minimalist approach to addressing issue #1657. This does **not** completely change the color specification syntax to align with the `color` package or the `xcolor` package. It does not accommodate RGB notation or a cmyk color model.  It does, however, allow a 6-digit HTML color specification to pass without a leading `#` symbol, as in `xcolor`'s HTML color model.