### PR TITLE
chore(package): update file-loader to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-flowtype": "^2.40.1",
     "eslint-plugin-react": "^7.10.0",
     "eslint-plugin-transform-runtime-aliasing": "^1.2.0",
-    "file-loader": "^1.1.11",
+    "file-loader": "^2.0.0",
     "flow-bin": "^0.80.0",
     "fs-extra": "^7.0.0",
     "greenkeeper-lockfile": "^1.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3030,12 +3030,12 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.11.tgz#6fe886449b0f2a936e43cabaac0cdbfb369506f8"
+file-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-2.0.0.tgz#39749c82f020b9e85901dcff98e8004e6401cfde"
   dependencies:
     loader-utils "^1.0.2"
-    schema-utils "^0.4.5"
+    schema-utils "^1.0.0"
 
 filename-regex@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Somehow Greenkeeper missed this, possibly due to recent GitHub or NPM downtime.