### PR TITLE
Remove greenkeeper-lockfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,14 +38,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - yarn-deps-v2-{{ checksum "yarn.lock" }}
-            - yarn-deps-v2-
+            - yarn-deps-v3-{{ checksum "yarn.lock" }}
+            - yarn-deps-v3-
       - run:
           name: Install dependencies
           # upgrade Yarn before installing dependencies, if needed
           command: yarn check || { curl -o- -L https://yarnpkg.com/install.sh | bash && yarn; }
       - save_cache:
-          key: yarn-deps-v2-{{ checksum "yarn.lock" }}
+          key: yarn-deps-v3-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
 
@@ -96,20 +96,6 @@ jobs:
       - skip_if_only_changed:
           filter: '^docs/|^LICENSE|\.md$'
       - install_dependencies
-
-      - add_ssh_keys:
-          fingerprints:
-            - "e1:ac:13:98:98:8b:fd:38:81:12:28:55:75:a1:da:73"
-      - run:
-          name: Greenkeeper - update and commit yarn.lock
-          environment:
-            # greenkeeper-lockfile detects build by checking it's the first job
-            # of the first workflow. As we run jobs parallel, it may not be the
-            # first job
-            CIRCLE_PREVIOUS_BUILD_NUM: ""
-          command: |
-              ./node_modules/.bin/greenkeeper-lockfile-update
-              ./node_modules/.bin/greenkeeper-lockfile-upload
 
       - run:
           name: Lint code

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "file-loader": "^2.0.0",
     "flow-bin": "^0.80.0",
     "fs-extra": "^7.0.0",
-    "greenkeeper-lockfile": "^1.15.1",
     "husky": "^1.0.0-rc.8",
     "istanbul-api": "^2.0.5",
     "istanbul-lib-coverage": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,14 +3378,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-greenkeeper-lockfile@^1.15.1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/greenkeeper-lockfile/-/greenkeeper-lockfile-1.15.1.tgz#289728213f8d4731596fdb011e3c6eb24ee96a73"
-  dependencies:
-    lodash "^4.17.4"
-    require-relative "^0.8.7"
-    semver "^5.3.0"
-
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -6731,10 +6723,6 @@ require-from-string@^2.0.1:
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-
-require-relative@^0.8.7:
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Greenkeeper now has built-in support for updating lockfiles: https://blog.greenkeeper.io/announcing-native-lockfile-support-85381a37a0d0.