### PR TITLE
Support Unicode double square brackets

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -60,7 +60,7 @@ See also [letters](#letters)
 |$\vert$ <code>&#124;</code> |$\vert$ `\vert` |$┌ ┐$ `┌ ┐`|$\ulcorner \urcorner$ `\ulcorner`<br>$~~~~$`\urcorner`  |$\Downarrow$ `\Downarrow`
 |$\Vert$ <code>&#92;&#124;</code> |$\Vert$ `\Vert` |$└ ┘$ `└ ┘`|$\llcorner \lrcorner$ `\llcorner`<br>$~~~~$`\lrcorner`  |$\Updownarrow$ `\Updownarrow`
 |$\lvert~\rvert$ `\lvert`<br>$~~~~$`\rvert`|$\lVert~\rVert$ `\lVert`<br>$~~~~~$`\rVert` |`\left.`|  `\right.` |$\backslash$ `\backslash`
-|$\lang~\rang$ `\lang`<br>$~~~~$`\rang`|$\lt~\gt$ `\lt \gt`|
+|$\lang~\rang$ `\lang`<br>$~~~~$`\rang`|$\lt~\gt$ `\lt \gt`|$⟦~⟧$ `⟦ ⟧`|
 
 **Delimiter Sizing**
 

--- a/src/macros.js
+++ b/src/macros.js
@@ -803,6 +803,18 @@ defineMacro("\\limsup", "\\DOTSB\\mathop{\\operatorname{lim\\,sup}}\\limits");
 defineMacro("\\liminf", "\\DOTSB\\mathop{\\operatorname{lim\\,inf}}\\limits");
 
 //////////////////////////////////////////////////////////////////////
+// semantic
+
+// The semantic package renders the next two items by calling a glyph from the
+// bbold package. Those glyphs do not exist in the KaTeX fonts. Hence the macros.
+
+defineMacro("\u27e6", "\\mathopen{[\\mkern-3.2mu[}");  // blackboard bold [
+defineMacro("\u27e7", "\\mathclose{]\\mkern-3.2mu]}"); // blackboard bold ]
+
+// TODO: Create variable sized versions of the last two items. I believe that
+// will require new font glyphs.
+
+//////////////////////////////////////////////////////////////////////
 // texvc.sty
 
 // The texvc package contains macros available in mediawiki pages.

--- a/test/katex-spec.js
+++ b/test/katex-spec.js
@@ -3216,6 +3216,7 @@ describe("Unicode", function() {
         expect("\\left\u23b0\\frac{a}{b}\\right\u23b1").toBuild();
         expect`┌x┐ └x┘`.toBuild();
         expect("\u231Cx\u231D \u231Ex\u231F").toBuild();
+        expect("\u27E6x\u27E7").toBuild();
     });
 
     it("should build some surrogate pairs", function() {


### PR DESCRIPTION
This PR adds support for the Unicode characters ⟦ and ⟧. The proposed additions are not variable sized.

I tried and failed to make variable sized delimiters. I believe that new font glyphs will be necessary in order to make them variable sized.

I do not include any function names for the delimiters in this PR. I can't use names like `\ldbrack` or `\lBrack` because those are names for variable sized delimiters. There are a couple of packages that define function names for text-mode brackets, but they don't get delimiter spacing and they look remarkably out of place without that spacing.

So the PR uses only the Unicode characters. This follows the `semantic` package, which provide a non-variable sized delimiter with delimiter spacing. They render it by using a glyph from the `bbold` package. We don't have that glyph so I wrote a macro with a little negative spacing.